### PR TITLE
travis-ci: update distros and repos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,16 +14,20 @@ env:
       - TARGET=test VERSION=1_10
       - TARGET=test VERSION=2x
       - TARGET=test VERSION=2_2
+      - TARGET=test VERSION=2_3
+      - TARGET=test VERSION=2_4
       - OS=el DIST=6
       - OS=el DIST=7
+      - OS=el DIST=8
       - OS=fedora DIST=28
       - OS=fedora DIST=29
       - OS=fedora DIST=30
+      - OS=fedora DIST=31
       - OS=ubuntu DIST=trusty
       - OS=ubuntu DIST=xenial
       - OS=ubuntu DIST=bionic
-      - OS=ubuntu DIST=cosmic
-      - OS=ubuntu DIST=disco
+      - OS=ubuntu DIST=eoan
+      - OS=ubuntu DIST=focal
       - OS=debian DIST=jessie
       - OS=debian DIST=stretch
       - OS=debian DIST=buster
@@ -76,6 +80,28 @@ deploy:
       branch: master
       condition: -n "${OS}" && -n "${DIST}" && -n "${PACKAGECLOUD_TOKEN}" && "${TRAVIS_EVENT_TYPE}" != 'cron'
 
+  - provider: packagecloud
+    username: tarantool
+    repository: "2_3"
+    token: ${PACKAGECLOUD_TOKEN}
+    dist: ${OS}/${DIST}
+    package_glob: build/*.{rpm,deb,dsc}
+    skip_cleanup: true
+    on:
+      branch: master
+      condition: -n "${OS}" && -n "${DIST}" && -n "${PACKAGECLOUD_TOKEN}" && "${TRAVIS_EVENT_TYPE}" != 'cron'
+
+  - provider: packagecloud
+    username: tarantool
+    repository: "2_4"
+    token: ${PACKAGECLOUD_TOKEN}
+    dist: ${OS}/${DIST}
+    package_glob: build/*.{rpm,deb,dsc}
+    skip_cleanup: true
+    on:
+      branch: master
+      condition: -n "${OS}" && -n "${DIST}" && -n "${PACKAGECLOUD_TOKEN}" && "${TRAVIS_EVENT_TYPE}" != 'cron'
+
   # Deploy packages to PackageCloud from tags
   # see:
   #   * https://github.com/tarantool/tarantool/issues/3745
@@ -105,6 +131,28 @@ deploy:
   - provider: packagecloud
     username: tarantool
     repository: "2_2"
+    token: ${PACKAGECLOUD_TOKEN}
+    dist: ${OS}/${DIST}
+    package_glob: build/*.{rpm,deb,dsc}
+    skip_cleanup: true
+    on:
+      tags: true
+      condition: -n "${OS}" && -n "${DIST}" && -n "${PACKAGECLOUD_TOKEN}" && "${TRAVIS_EVENT_TYPE}" != 'cron'
+
+  - provider: packagecloud
+    username: tarantool
+    repository: "2_3"
+    token: ${PACKAGECLOUD_TOKEN}
+    dist: ${OS}/${DIST}
+    package_glob: build/*.{rpm,deb,dsc}
+    skip_cleanup: true
+    on:
+      tags: true
+      condition: -n "${OS}" && -n "${DIST}" && -n "${PACKAGECLOUD_TOKEN}" && "${TRAVIS_EVENT_TYPE}" != 'cron'
+
+  - provider: packagecloud
+    username: tarantool
+    repository: "2_4"
     token: ${PACKAGECLOUD_TOKEN}
     dist: ${OS}/${DIST}
     package_glob: build/*.{rpm,deb,dsc}


### PR DESCRIPTION
* Drop EOL distros: Ubuntu Cosmic and Disco.
* Add new distros: CentOS 8, Fedora 31, Ubuntu Eoan, Ubuntu Focal.
* Add testing on tarantool 2.3 and 2.4.
* Push packages to 2.3 and 2.4 repositories.