### PR TITLE
Use actual data for expirations

### DIFF
--- a/expirationd.lua
+++ b/expirationd.lua
@@ -94,9 +94,9 @@ local function tree_index_iter(scan_space, task)
         for _, tuple in ipairs(tuples) do
             expiration_process(task, tuple)
         end
+        suspend(scan_space, task)
         local key = construct_key(scan_space.id, last_id)
         tuples = scan_space.index[0]:select(key, params)
-        suspend(scan_space, task)
     end
 
 end


### PR DESCRIPTION
Thread1:
```
s = box.schema.create_space('c', {
                                  >         if_not_exists = true,
                                  >     })
s:create_index('idx', {
                                  >         type = 'tree',
                                  >         unique = true,
                                  >         parts = {
                                  >             1, 'unsigned',
                                  >         },
                                  >         if_not_exists = true,
                                  >     })
box.space.c:insert({1, 2})
d = box.space.c:select()
```
Thread2:
```
box.space.c:update(1, {
            {'=', 1, 3},
        })
```
Thread1:
```
> d
---
- - [1, 2]
```