### PR TITLE
Remove Ubuntu Eoan from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ env:
       - OS=ubuntu DIST=trusty
       - OS=ubuntu DIST=xenial
       - OS=ubuntu DIST=bionic
-      - OS=ubuntu DIST=eoan
       - OS=ubuntu DIST=focal
       - OS=debian DIST=jessie
       - OS=debian DIST=stretch


### PR DESCRIPTION
Ubuntu Eoan is EOL and fails in CI on apt repositories updating with 'does not have a Release file' errors.