### PR TITLE
Features for more customized behavior

### DIFF
--- a/.github/workflows/fast_testing.yaml
+++ b/.github/workflows/fast_testing.yaml
@@ -35,4 +35,16 @@ jobs:
       - name: Clone the module
         uses: actions/checkout@v2
 
+      - name: Cache rocks
+        uses: actions/cache@v2
+        id: cache-rocks
+        with:
+          path: .rocks/
+          key: cache-rocks-${{ matrix.tarantool }}-01
+
+      - name: Install requirements
+        run: |
+          tarantoolctl rocks install luatest 0.5.0
+        if: steps.cache-rocks.outputs.cache-hit != 'true'
+
       - run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 all:
 	@echo "Only tests are available: make test"
 
+.PHONY: test
 test:
+	.rocks/bin/luatest -v
 	rm -rf *.xlog* *.snap 51{2,3,4,5,6,7}
 	INDEX_TYPE='TREE' SPACE_TYPE='vinyl' ./test.lua
 	rm -rf *.xlog* *.snap 51{2,3,4,5,6,7}

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Run a scheduled task to check and process (expire) tuples in a given space.
      The index value may be a single value, if the index consists of one field, a tuple with the index key parts, or a function which returns such value.
      If omitted or nil, all tuples will be checked.
     * `tuples_per_iteration` - Number of tuples to check in one batch (iteration). Default is 1024.
+    * `atomic_iteration` - Boolean, false (default) to process each tuple as a single transaction.
+     True to process tuples from each batch in a single transaction.
     * `process_while` - Function to call before checking each tuple.
      If it returns false, the current tuple scan task finishes.
     * `iterate_with` - Function which returns an iterator object which provides tuples to check, considering the start_key, process_while and other options.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ Run a scheduled task to check and process (expire) tuples in a given space.
      The index value may be a single value, if the index consists of one field, a tuple with the index key parts, or a function which returns such value.
      If omitted or nil, all tuples will be checked.
     * `tuples_per_iteration` - Number of tuples to check in one batch (iteration). Default is 1024.
+    * `process_while` - Function to call before checking each tuple.
+     If it returns false, the current tuple scan task finishes.
+    * `iterate_with` - Function which returns an iterator object which provides tuples to check, considering the start_key, process_while and other options.
+     There's a default function which can be overriden with this parameter.
     * `on_full_scan_start` - Function to call before starting a tuple scan.
     * `on_full_scan_complete` - Function to call after completing a full scan.
     * `on_full_scan_success` - Function to call after successfully completing a full scan.

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ being deleted into some other space.
 ``` lua
 box.cfg{}
 space = box.space.old
-job_name = 'clean_all'
-expirationd = require('expirationd')
+job_name = "clean_all"
+expirationd = require("expirationd")
 function is_expired(args, tuple)
   return true
 end
@@ -31,35 +31,30 @@ expirationd.start(job_name, space.id, is_expired, {
 
 ### `expirationd.start (name, space_id, is_tuple_expired, options)`
 
-Run a named task
+Run a scheduled task to check and process (expire) tuples in a given space.
 
 * `name` - task name
 * `space_id` - space to look in for expired tuples
 * `is_tuple_expired` - a function, must accept tuple and return true/false
   (is tuple expired or not), receives `(args, tuple)` as arguments
-opt
 * `options` -- (table with named options, may be nil)
-  * `process_expired_tuple` - applied to expired tuples, receives `(space_id, args, tuple)`
-    as arguments. Can be nil: by default tuples are removed
-  * `args` - passed to `is_tuple_expired()` and `process_expired_tuple()` as additional context
-  * `tuples_per_iteration` - number of tuples will be checked by one iteration
-  * `full_scan_time` - time required for full index scan (in seconds)
-  * `iteration_delay` - max sleep time between iterations (in seconds)
-  * `full_scan_delay` - sleep time between full scans (in seconds)
-  * `on_full_scan_start` - call function on starting full scan iteration
-    Receives `(task)` as arguments.
-  * `on_full_scan_complete` - call function on complete full scan iteration.
-    Called after `on_full_scan_success` or `on_full_scan_error`.
-    Receives `(task)` as arguments.
-  * `on_full_scan_success` - call function on success full scan iteration
-    Receives `(task)` as arguments.
-  * `on_full_scan_error` - call function on error full scan iteration
-    Receives `(task, error)` as arguments.
-  * `force` - run, even on replica
+    * `process_expired_tuple` - Applied to expired tuples, receives (space_id, args, tuple) as arguments.
+     Can be nil: by default, tuples are removed.
+    * `tuples_per_iteration` - Number of tuples to check in one batch (iteration). Default is 1024.
+    * `on_full_scan_start` - Function to call before starting a tuple scan.
+    * `on_full_scan_complete` - Function to call after completing a full scan.
+    * `on_full_scan_success` - Function to call after successfully completing a full scan.
+    * `on_full_scan_error` - Function to call after terminating a full scan due to an error.
+    * `args` - Passed to is_tuple_expired and process_expired_tuple() as an additional context.
+    * `full_scan_time` - Time required for a full index scan (in seconds).
+    * `iteration_delay` - Max sleep time between batches (in seconds).
+    * `full_scan_delay` - Sleep time between full scans (in seconds).
+    * `force` - Run task even on replica.
+
 
 ### `expirationd.kill (name)`
 
-Kill an existing task with name 'name'
+Kill an existing task with name "name"
 
 * `name` - task's name
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ Run a scheduled task to check and process (expire) tuples in a given space.
     * `index` - Name or id of the index to iterate on. If omitted, will use the primary index.
      If there's no index with this name, will throw an error.
      Supported index types are TREE and HASH, using other types will result in an error.
+    * `iterator_type` - Type of the iterator to use, as string or box.index constant, for example, "EQ" or box.index.EQ.
+     Default is box.index.ALL.
+     See https://www.tarantool.io/en/doc/latest/reference/reference_lua/box_index/pairs/.
+    * `start_key` - Start iterating from the tuple with this index value. If the iterator is "EQ", iterate over tuples with this index value.
+     The index value may be a single value, if the index consists of one field, a tuple with the index key parts, or a function which returns such value.
+     If omitted or nil, all tuples will be checked.
     * `tuples_per_iteration` - Number of tuples to check in one batch (iteration). Default is 1024.
     * `on_full_scan_start` - Function to call before starting a tuple scan.
     * `on_full_scan_complete` - Function to call after completing a full scan.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ Run a scheduled task to check and process (expire) tuples in a given space.
 * `options` -- (table with named options, may be nil)
     * `process_expired_tuple` - Applied to expired tuples, receives (space_id, args, tuple) as arguments.
      Can be nil: by default, tuples are removed.
+    * `index` - Name or id of the index to iterate on. If omitted, will use the primary index.
+     If there's no index with this name, will throw an error.
+     Supported index types are TREE and HASH, using other types will result in an error.
     * `tuples_per_iteration` - Number of tuples to check in one batch (iteration). Default is 1024.
     * `on_full_scan_start` - Function to call before starting a tuple scan.
     * `on_full_scan_complete` - Function to call after completing a full scan.

--- a/test/helper.lua
+++ b/test/helper.lua
@@ -1,0 +1,111 @@
+local t = require("luatest")
+local fio = require("fio")
+
+local helpers = require("luatest.helpers")
+
+t.before_suite(function()
+    t.datadir = fio.tempdir()
+    box.cfg{
+        wal_dir    = t.datadir,
+        memtx_dir  = t.datadir,
+        vinyl_dir  = t.datadir,
+    }
+
+    local tree = box.schema.create_space("tree", { if_not_exists = true })
+    tree:format({
+        {name = "id", type = "number"},
+        {name = "first_name", type = "string"},
+        {name = "value", type = "number", is_nullable = true},
+        {name = "count", type = "number", is_nullable = true},
+        {name = "non_unique_id", type = "number", is_nullable = true, unique = false},
+        {name = "json_path_field", is_nullable = true, unique = false},
+        {name = "multikey_field", is_nullable = true},
+        {name = "functional_field", is_nullable = true},
+    })
+    tree:create_index("primary", {type = "TREE", parts={ 1 }})
+    tree:create_index("index_for_first_name", {type = "TREE", parts={ 2 }})
+    tree:create_index("multipart_index", {type = "TREE", parts={ {3, is_nullable = true}, {4, is_nullable = true} }})
+    tree:create_index("non_unique_index", {type = "TREE", parts={ {5, is_nullable = true} }, unique = false})
+
+    local hash = box.schema.create_space("hash", { if_not_exists = true })
+    hash:format({
+        {name = "id", type = "number"},
+        {name = "first_name", type = "string"},
+        {name = "value", type = "number", is_nullable = true},
+        {name = "count", type = "number", is_nullable = true}
+    })
+    hash:create_index("primary", {type = "HASH", parts={ 1 }} )
+    hash:create_index("index_for_first_name", {type = "HASH", parts={ 2 }} )
+    hash:create_index("multipart_index", {type = "HASH", parts={ {1}, {2} }})
+
+    local vinyl = box.schema.create_space("vinyl", { if_not_exists = true, engine = "vinyl" })
+    vinyl:format({
+        {name = "id", type = "number"},
+        {name = "first_name", type = "string"},
+        {name = "value", type = "number", is_nullable = true},
+        {name = "count", type = "number", is_nullable = true},
+        {name = "non_unique_id", type = "number", is_nullable = true, unique = false},
+        {name = "json_path_field", is_nullable = true, unique = false},
+        {name = "multikey_field", is_nullable = true, unique = false},
+    })
+    vinyl:create_index("primary", {type = "TREE", parts={ 1 }})
+    vinyl:create_index("index_for_first_name", {type = "TREE", parts={ 2 }})
+    vinyl:create_index("multipart_index", {type = "TREE", parts={ {3, is_nullable = true}, {4, is_nullable = true} }})
+    vinyl:create_index("non_unique_index", {type = "TREE", parts={ {5} }, unique = false })
+
+    if _TARANTOOL >= "2" then
+        local tree_code = [[function(tuple)
+            if tuple[8] then
+                return {string.sub(tuple[8],2,2)}
+            end
+            return {tuple[2]}
+        end]]
+        box.schema.func.create("tree_func",
+                {body = tree_code, is_deterministic = true, is_sandboxed = true})
+        tree:create_index("json_path_index",
+                {type = "TREE", parts = { {6, type = "scalar", path = "age", is_nullable = true} }})
+        tree:create_index("multikey_index",
+                {type = "TREE", parts = { {7, type = "str", path = "data[*].name"} }} )
+        tree:create_index("functional_index",
+                {type = "TREE", parts={ {1, type = "string"} }, func = "tree_func"})
+
+        vinyl:create_index("json_path_index",
+                {type = "TREE", parts = { {6, type = "scalar", path = "age", is_nullable = true} }})
+        vinyl:create_index("multikey_index",
+                {type = "TREE", parts = { {7, type = "str", path = "data[*].name", is_nullable = true} }})
+    end
+
+    local bitset = box.schema.create_space("bitset", { if_not_exists = true })
+    bitset:create_index("primary", {type = "TREE", parts={ 1 }})
+    bitset:create_index("index_for_first_name",
+            {type = "BITSET", parts={ {field = 2, type = "string"} }, unique = false})
+end)
+
+t.after_suite(function()
+    fio.rmtree(t.datadir)
+end)
+
+function helpers.init_spaces(g)
+    g.tree = box.space.tree
+    g.hash = box.space.hash
+    g.vinyl = box.space.vinyl
+    g.bitset = box.space.bitset
+end
+
+function helpers.truncate_spaces(g)
+    g.tree:truncate()
+    g.hash:truncate()
+    g.vinyl:truncate()
+end
+
+function helpers.is_expired_true()
+    return true
+end
+
+helpers.iteration_result = {}
+function helpers.is_expired_debug(_, tuple)
+    table.insert(helpers.iteration_result, tuple)
+    return true
+end
+
+return helpers

--- a/test/helper.lua
+++ b/test/helper.lua
@@ -9,6 +9,7 @@ t.before_suite(function()
         wal_dir    = t.datadir,
         memtx_dir  = t.datadir,
         vinyl_dir  = t.datadir,
+        vinyl_memory = 1024,
     }
 
     local tree = box.schema.create_space("tree", { if_not_exists = true })

--- a/test/unit/atomic_iteration_test.lua
+++ b/test/unit/atomic_iteration_test.lua
@@ -1,0 +1,175 @@
+local fiber = require("fiber")
+local expirationd = require("expirationd")
+local t = require("luatest")
+local g = t.group("atomic_iteration")
+
+local helpers = require("test.helper")
+
+g.before_all(function()
+    helpers.init_spaces(g)
+end)
+
+g.after_each(function()
+    helpers.truncate_spaces(g)
+end)
+
+function g.test_passing()
+    local task = expirationd.start("clean_all", g.tree.id, helpers.is_expired_true)
+    t.assert_equals(task.atomic_iteration, false)
+    task:kill()
+
+    task = expirationd.start("clean_all", g.tree.id, helpers.is_expired_true,
+            {atomic_iteration = true})
+    t.assert_equals(task.atomic_iteration, true)
+    task:kill()
+
+    -- errors
+    t.assert_error_msg_content_equals("Invalid type of atomic_iteration, expected boolean",
+            expirationd.start, "clean_all", g.tree.id, helpers.is_expired_true,
+            {atomic_iteration = 1})
+end
+
+function g.test_memtx()
+    helpers.iteration_result = {}
+
+    local transactions = {}
+    local function f(iterator)
+        local transaction = {}
+        -- old / new_tuple is not passed for vinyl
+        for request_number, old_tuple, new_tuple, space_id in iterator() do
+            table.insert(transaction, old_tuple:totable())
+        end
+        table.insert(transactions, transaction)
+    end
+
+    local true_box_begin = box.begin
+
+    -- mock box.begin
+    box.begin = function ()
+        true_box_begin()
+        box.on_commit(f)
+    end
+
+    for _, space in pairs({g.tree, g.hash}) do
+        -- tuples expired in one atomic_iteration
+        space:insert({1, "3"})
+        space:insert({2, "2"})
+        space:insert({3, "1"})
+
+
+        local task = expirationd.start("clean_all", space.id, helpers.is_expired_debug,
+                {atomic_iteration = true})
+        -- wait for tuples expired
+        helpers.retrying({}, function()
+            if space.index[0].type == "HASH" then
+                t.assert_equals(helpers.iteration_result, {{3, "1"}, {2, "2"}, {1, "3"}})
+            else
+                t.assert_equals(helpers.iteration_result, {{1, "3"}, {2, "2"}, {3, "1"}})
+            end
+        end)
+        task:kill()
+        helpers.iteration_result = {}
+
+        -- check out three row transaction
+        if space.index[0].type == "HASH" then
+            t.assert_equals(transactions, {
+                { {3, "1"}, {2, "2"}, {1, "3"} }
+            })
+        else
+            t.assert_equals(transactions, {
+                { {1, "3"}, {2, "2"}, {3, "1"} }
+            })
+        end
+        transactions = {}
+
+        -- tuples expired in two atomic_iteration
+        space:insert({1, "3"})
+        space:insert({2, "2"})
+        space:insert({3, "1"})
+
+        task = expirationd.start("clean_all", space.id, helpers.is_expired_debug,
+                {atomic_iteration = true, tuples_per_iteration = 2})
+        -- wait for tuples expired
+        -- 2 seconds because suspend will be yield in task
+        helpers.retrying({}, function()
+            if space.index[0].type == "HASH" then
+                t.assert_equals(helpers.iteration_result, {{3, "1"}, {2, "2"}, {1, "3"}})
+            else
+                t.assert_equals(helpers.iteration_result, {{1, "3"}, {2, "2"}, {3, "1"}})
+            end
+        end)
+        task:kill()
+        helpers.iteration_result = {}
+
+        if space.index[0].type == "HASH" then
+            t.assert_equals(transactions, {
+                { {3, "1"}, {2, "2"} }, -- check two row transaction
+                { {1, "3"} }            -- check single row transactions
+            })
+        else
+            t.assert_equals(transactions, {
+                { {1, "3"}, {2, "2"} }, -- check two row transaction
+                { {3, "1"} }            -- check single row transactions
+            })
+        end
+
+        transactions = {}
+    end
+
+    -- unmock
+    box.begin = true_box_begin
+end
+
+-- it's not check tarantool or vinyl as engine
+-- just check expirationd task continue work after conflicts
+function g.test_mvcc_vinyl_tx_conflict()
+    for i = 1,10 do
+        g.vinyl:insert({i, tostring(i), nil, nil, 0})
+    end
+
+    local updaters = {}
+    for i = 1,10 do
+        local updater = fiber.create(function()
+            fiber.name(string.format("updater of %d", i), { truncate = true })
+            while true do
+                g.vinyl:update({i}, { {"+", 5, 1} })
+                fiber.yield()
+            end
+        end)
+        table.insert(updaters, updater)
+    end
+
+    local task = expirationd.start("clean_all", g.vinyl.id, helpers.is_expired_debug,
+            {atomic_iteration = true})
+
+    -- wait for tuples expired
+    fiber.sleep(3)
+
+    for i = 1,10 do
+        updaters[i]:cancel()
+    end
+
+    helpers.retrying({}, function()
+        t.assert_equals(g.vinyl:select(), {})
+    end)
+    t.assert(box.stat.vinyl().tx.conflict > 0)
+    t.assert_equals(box.stat.vinyl().tx.conflict, box.stat.vinyl().tx.rollback)
+    t.assert_equals(box.stat.vinyl().tx.transactions, 0)
+    task:kill()
+end
+
+function g.test_kill_task()
+    for i = 1,1024*10 do
+        g.tree:insert({i, tostring(i)})
+    end
+
+    local task = expirationd.start("clean_all", g.tree.id, helpers.is_expired_debug,
+            {atomic_iteration = true})
+
+    task:kill()
+    t.assert(g.tree:count() > 0)
+    t.assert(g.tree:count() % 1024 == 0)
+
+    -- return to default value
+    box.cfg{vinyl_memory = 134217728}
+end

--- a/test/unit/custom_index_test.lua
+++ b/test/unit/custom_index_test.lua
@@ -1,0 +1,259 @@
+local expirationd = require("expirationd")
+local t = require("luatest")
+local g = t.group("custom_index")
+
+local helpers = require("test.helper")
+
+g.before_all(function()
+    helpers.init_spaces(g)
+end)
+
+g.after_each(function()
+    helpers.truncate_spaces(g)
+end)
+
+function g.test_passing()
+    local task = expirationd.start("clean_all", g.tree.id, helpers.is_expired_true)
+    -- if we don't specify index, program should use primary index
+    t.assert_equals(task.index, box.space.tree.index[0])
+    task:kill()
+
+    -- index by name
+    task = expirationd.start("clean_all", g.tree.id, helpers.is_expired_true,
+            {index = "index_for_first_name"})
+    t.assert_equals(task.index, box.space.tree.index[1])
+    task:kill()
+
+    -- index by id
+    task = expirationd.start("clean_all", g.tree.id, helpers.is_expired_true,
+            {index = 1})
+    t.assert_equals(task.index, box.space.tree.index[1])
+    task:kill()
+
+    -- errors
+    t.assert_error_msg_content_equals("Index with name not_exists_index does not exist",
+            expirationd.start, "clean_all", g.tree.id, helpers.is_expired_true,
+            {index = "not_exists_index"})
+    t.assert_error_msg_content_equals("Index with id 10 does not exist",
+            expirationd.start, "clean_all", g.tree.id, helpers.is_expired_true,
+            {index = 10})
+    t.assert_error_msg_content_equals("Invalid type of index, expected string or number",
+            expirationd.start, "clean_all", g.tree.id, helpers.is_expired_true,
+            {index = { 10 }})
+end
+
+function g.test_tree_index()
+    for _, space in pairs({g.tree, g.vinyl}) do
+        helpers.iteration_result = {}
+
+        space:insert({1, "3"})
+        space:insert({2, "2"})
+        space:insert({3, "1"})
+
+        -- check default primary index
+        local task = expirationd.start("clean_all", space.id, helpers.is_expired_debug)
+        -- wait for tuples expired
+        helpers.retrying({}, function()
+            t.assert_equals(helpers.iteration_result, {
+                {1, "3"},
+                {2, "2"},
+                {3, "1"}
+            })
+        end)
+        task:kill()
+        helpers.iteration_result = {}
+
+        space:insert({1, "3"})
+        space:insert({2, "2"})
+        space:insert({3, "1"})
+
+        -- check custom index
+        task = expirationd.start("clean_all", space.id, helpers.is_expired_debug,
+                {index = "index_for_first_name"})
+        -- wait for tuples expired
+        helpers.retrying({}, function()
+            t.assert_equals(helpers.iteration_result, {
+                {3, "1"},
+                {2, "2"},
+                {1, "3"}
+            })
+        end)
+        task:kill()
+    end
+end
+
+function g.test_tree_index_non_unique()
+    for _, space in pairs({g.tree, g.vinyl}) do
+        helpers.iteration_result = {}
+
+        space:insert({1, "3", nil, nil, 1})
+        space:insert({2, "2", nil, nil, 2})
+        space:insert({3, "1", nil, nil, 1})
+
+        local task = expirationd.start("clean_all", space.id, helpers.is_expired_debug,
+                {index = "non_unique_index"})
+        -- wait for tuples expired
+        helpers.retrying({}, function()
+            t.assert_equals(helpers.iteration_result, {
+                        {1, "3", nil, nil, 1},
+                        {3, "1", nil, nil, 1},
+                        {2, "2", nil, nil, 2}
+                    })
+        end)
+        task:kill()
+    end
+end
+
+function g.test_tree_index_multipart()
+    for _, space in pairs({g.tree, g.vinyl}) do
+        helpers.iteration_result = {}
+
+        space:insert({1, "1", 2, 1})
+        space:insert({2, "2", 2, 2})
+        space:insert({3, "3", 1, 3})
+
+        local task = expirationd.start("clean_all", space.id, helpers.is_expired_debug,
+                {index = "multipart_index"})
+        -- wait for tuples expired
+        helpers.retrying({}, function()
+            t.assert_equals(helpers.iteration_result, {
+                {3, "3", 1, 3},
+                {1, "1", 2, 1},
+                {2, "2", 2, 2}
+            })
+        end)
+        task:kill()
+    end
+end
+
+if _TARANTOOL >= "2" then
+    function g.test_tree_index_json_path()
+        for _, space in pairs({g.tree, g.vinyl}) do
+            helpers.iteration_result = {}
+
+            space:insert({1, "1", nil, nil, nil, { age  = 3 }})
+            space:insert({2, "2", nil, nil, nil, { age  = 1 }})
+            space:insert({3, "3", nil, nil, nil, { age  = 2 }})
+            space:insert({4, "4", nil, nil, nil, { days = 3 }})
+            space:insert({5, "5", nil, nil, nil, { days = 1 }})
+            space:insert({6, "6", nil, nil, nil, { days = 2 }})
+
+
+            local task = expirationd.start("clean_all", space.id, helpers.is_expired_debug,
+                    {index = "json_path_index"})
+            -- wait for tuples expired
+            helpers.retrying({}, function()
+                t.assert_equals(helpers.iteration_result, {
+                    {4, "4", nil, nil, nil, { days = 3 }},
+                    {5, "5", nil, nil, nil, { days = 1 }},
+                    {6, "6", nil, nil, nil, { days = 2 }},
+                    {2, "2", nil, nil, nil, { age = 1 }},
+                    {3, "3", nil, nil, nil, { age = 2 }},
+                    {1, "1", nil, nil, nil, { age = 3 }}
+                })
+            end)
+            task:kill()
+        end
+    end
+
+    function g.test_tree_index_multikey()
+        for _, space in pairs({g.tree, g.vinyl}) do
+            helpers.iteration_result = {}
+
+            space:insert({1, "1", nil, nil, nil, nil, {data = {{name = "A"},
+                                                               {name = "B"}},
+                                                       extra_field = 1}})
+
+            local task = expirationd.start("clean_all", space.id, helpers.is_expired_debug,
+                    {index = "multikey_index"})
+            -- wait for tuples expired
+            helpers.retrying({}, function()
+                -- met only once, since we delete and cannot walk a second time on name = "B"
+                t.assert_equals(helpers.iteration_result, {
+                    {1, "1", nil, nil, nil, nil, {data = {{name = "A"},
+                                                          {name = "B"}},
+                                                  extra_field = 1}}
+                })
+            end)
+            task:kill()
+        end
+    end
+
+    function g.test_memtx_tree_functional_index()
+        -- vinyl doesn't support functional indexes
+        helpers.iteration_result = {}
+
+        g.tree:insert({1, "1", nil, nil, nil, nil, nil, "12"})
+        g.tree:insert({2, "2", nil, nil, nil, nil, nil, "21"})
+
+        local task = expirationd.start("clean_all", g.tree.id, helpers.is_expired_debug,
+                {index = "functional_index"})
+        -- wait for tuples expired
+        helpers.retrying({}, function()
+            -- sort by second character to eighth field
+            t.assert_equals(helpers.iteration_result, {
+                {2, "2", nil, nil, nil, nil, nil, "21"},
+                {1, "1", nil, nil, nil, nil, nil, "12"}
+            })
+        end)
+        task:kill()
+    end
+end
+
+
+function g.test_hash_index()
+    helpers.iteration_result = {}
+    g.hash:insert({1, "a"})
+    g.hash:insert({2, "b"})
+    g.hash:insert({3, "c"})
+
+    -- check default primary index
+    local task = expirationd.start("clean_all", g.hash.id, helpers.is_expired_debug)
+    -- wait for tuples expired
+    helpers.retrying({}, function()
+        t.assert_equals(helpers.iteration_result, {
+            {3, "c"},
+            {2, "b"},
+            {1, "a"}
+        })
+    end)
+    task:kill()
+
+    helpers.iteration_result = {}
+    g.hash:insert({1, "a"})
+    g.hash:insert({2, "b"})
+    g.hash:insert({3, "c"})
+
+    task = expirationd.start("clean_all", g.hash.id, helpers.is_expired_debug,
+            {index = "index_for_first_name"})
+    -- wait for tuples expired
+    helpers.retrying({}, function()
+        t.assert_equals(helpers.iteration_result, {
+            {1, "a"},
+            {3, "c"},
+            {2, "b"}
+        })
+    end)
+    helpers.iteration_result = {}
+    task:kill()
+end
+
+function g.test_hash_index_multipart()
+    helpers.iteration_result = {}
+
+    g.hash:insert({1, "1"})
+    g.hash:insert({2, "2"})
+    g.hash:insert({3, "3"})
+
+    local task = expirationd.start("clean_all", g.hash.id, helpers.is_expired_debug,
+            {index = "multipart_index"})
+    -- wait for tuples expired
+    helpers.retrying({}, function()
+        t.assert_equals(helpers.iteration_result, {
+            {2, "2"},
+            {1, "1"},
+            {3, "3"}
+        })
+    end)
+    task:kill()
+end

--- a/test/unit/iterate_with_test.lua
+++ b/test/unit/iterate_with_test.lua
@@ -1,0 +1,26 @@
+local expirationd = require("expirationd")
+local t = require("luatest")
+local g = t.group("iterate_with")
+
+local helpers = require("test.helper")
+
+g.before_all(function()
+    helpers.init_spaces(g)
+end)
+
+g.after_each(function()
+    helpers.truncate_spaces(g)
+end)
+
+function g.test_passing()
+    local task = expirationd.start("clean_all", g.tree.id, helpers.is_expired_true,
+            { iterate_with = helpers.is_expired_true })
+    -- default process_while always return false, iterations never stopped by this function
+    t.assert_equals(task.iterate_with, helpers.is_expired_true)
+    task:kill()
+
+    -- errors
+    t.assert_error_msg_content_equals("Invalid type of iterate_with, expected function",
+            expirationd.start, "clean_all", g.tree.id, helpers.is_expired_true,
+            { iterate_with = "" })
+end

--- a/test/unit/iterator_type_test.lua
+++ b/test/unit/iterator_type_test.lua
@@ -1,0 +1,520 @@
+local expirationd = require("expirationd")
+local t = require("luatest")
+local g = t.group("iterator_type")
+
+local helpers = require("test.helper")
+
+g.before_all(function()
+    helpers.init_spaces(g)
+end)
+
+g.after_each(function()
+    helpers.truncate_spaces(g)
+end)
+
+function g.test_passing_errors()
+    -- ========================== --
+    -- tree index
+    -- ========================== --
+    t.assert_error_msg_content_equals(
+            "Unknown iterator type 'ERROR'",
+            expirationd.start, "clean_all", g.tree.id, helpers.is_expired_true, {iterator_type = "ERROR"})
+
+    -- ========================== --
+    -- hash index
+    -- ========================== --
+    t.assert_error_msg_content_equals(
+            "Index 'primary' (HASH) of space 'hash' (memtx) does not support requested iterator type",
+            expirationd.start, "clean_all", g.hash.id, helpers.is_expired_true, {start_key = 1, iterator_type = 1})
+
+    t.assert_error_msg_content_equals(
+            "Index 'primary' (HASH) of space 'hash' (memtx) does not support requested iterator type",
+            expirationd.start, "clean_all", g.hash.id, helpers.is_expired_true, {start_key = 1, iterator_type = "GE"})
+
+    -- ========================== --
+    -- bitset index
+    -- ========================== --
+    t.assert_error_msg_content_equals(
+            "Not supported index type, expected TREE or HASH",
+            expirationd.start, "clean_all", g.bitset.id, helpers.is_expired_true, {index = "index_for_first_name"})
+end
+
+function g.test_passing_all()
+    -- ========================== --
+    -- tree index
+    -- ========================== --
+    local task = expirationd.start("clean_all", g.tree.id, helpers.is_expired_true)
+    -- default iterator_type for tree index is "ALL"
+    t.assert_equals(task.iterator_type, "ALL")
+    task:kill()
+
+    task = expirationd.start("clean_all", g.tree.id, helpers.is_expired_true,
+            {iterator_type = "ALL"})
+    t.assert_equals(task.iterator_type, "ALL")
+    task:kill()
+
+    -- ========================== --
+    -- hash index
+    -- ========================== --
+    task = expirationd.start("clean_all", g.hash.id, helpers.is_expired_true)
+    -- default iterator_type for hash index is "GE"
+    t.assert_equals(task.iterator_type, "ALL")
+    task:kill()
+
+    task = expirationd.start("clean_all", g.hash.id, helpers.is_expired_true,
+            {iterator_type = "ALL"})
+    t.assert_equals(task.iterator_type, "ALL")
+    task:kill()
+end
+
+function g.test_passing_eq()
+    -- ========================== --
+    -- tree index
+    -- ========================== --
+    local task = expirationd.start("clean_all", g.tree.id, helpers.is_expired_true,
+            {iterator_type = "EQ"})
+    t.assert_equals(task.iterator_type, "EQ")
+    task:kill()
+
+    -- ========================== --
+    -- hash index
+    -- ========================== --
+    task = expirationd.start("clean_all", g.hash.id, helpers.is_expired_true,
+            {start_key = 1, iterator_type = "EQ"})
+    t.assert_equals(task.iterator_type, "EQ")
+    task:kill()
+end
+
+function g.test_passing_gt()
+    -- ========================== --
+    -- tree index
+    -- ========================== --
+    local task = expirationd.start("clean_all", g.tree.id, helpers.is_expired_true,
+            {iterator_type = "GT"})
+    t.assert_equals(task.iterator_type, "GT")
+    task:kill()
+
+    -- ========================== --
+    -- hash index
+    -- ========================== --
+    task = expirationd.start("clean_all", g.hash.id, helpers.is_expired_true,
+            {iterator_type = "GT"})
+    t.assert_equals(task.iterator_type, "GT")
+    task:kill()
+end
+
+function g.test_passing_req()
+    -- ========================== --
+    -- tree index
+    -- ========================== --
+    local task = expirationd.start("clean_all", g.tree.id, helpers.is_expired_true,
+            {iterator_type = "REQ"})
+    t.assert_equals(task.iterator_type, "REQ")
+    task:kill()
+end
+
+function g.test_passing_ge()
+    -- ========================== --
+    -- tree index
+    -- ========================== --
+    local task = expirationd.start("clean_all", g.tree.id, helpers.is_expired_true,
+            {iterator_type = "GE"})
+    t.assert_equals(task.iterator_type, "GE")
+    task:kill()
+end
+
+function g.test_passing_lt()
+    -- ========================== --
+    -- tree index
+    -- ========================== --
+    local task = expirationd.start("clean_all", g.tree.id, helpers.is_expired_true,
+            {iterator_type = "LT"})
+    t.assert_equals(task.iterator_type, "LT")
+    task:kill()
+end
+
+function g.test_passing_le()
+    -- ========================== --
+    -- tree index
+    -- ========================== --
+    local task = expirationd.start("clean_all", g.tree.id, helpers.is_expired_true,
+            {iterator_type = "LE"})
+    t.assert_equals(task.iterator_type, "LE")
+    task:kill()
+end
+
+function g.test_tree_index_all()
+    for _, space in pairs({g.tree, g.vinyl}) do
+        -- without start key
+        helpers.iteration_result = {}
+        space:insert({1, "3"})
+        space:insert({2, "2"})
+        space:insert({3, "1"})
+
+        local task = expirationd.start("clean_all", space.id, helpers.is_expired_debug,
+                {iterator_type = "ALL"})
+        -- wait for tuples expired
+        helpers.retrying({}, function()
+            t.assert_equals(helpers.iteration_result, {
+                {1, "3"},
+                {2, "2"},
+                {3, "1"}
+            })
+        end)
+        task:kill()
+
+        -- with start_key
+        helpers.iteration_result = {}
+        space:insert({1, "3"})
+        space:insert({2, "2"})
+        space:insert({3, "1"})
+
+        task = expirationd.start("clean_all", space.id, helpers.is_expired_debug,
+                {iterator_type = "ALL", start_key = 2})
+        -- wait for tuples expired
+        helpers.retrying({}, function()
+            t.assert_equals(helpers.iteration_result, {
+                {2, "2"},
+                {3, "1"}
+            })
+        end)
+        task:kill()
+    end
+end
+
+function g.test_hash_index_all()
+    -- without start key
+    helpers.iteration_result = {}
+    g.hash:insert({3, "1"})
+    g.hash:insert({2, "2"})
+    g.hash:insert({1, "3"})
+
+    local task = expirationd.start("clean_all", g.hash.id, helpers.is_expired_debug,
+            {iterator_type = "ALL"})
+    -- wait for tuples expired
+    helpers.retrying({}, function()
+        t.assert_equals(helpers.iteration_result, {
+            {1, "3"},
+            {2, "2"},
+            {3, "1"}
+        })
+    end)
+    task:kill()
+
+    -- with start_key
+    -- Implicit behavior hash index ALL with start key
+    helpers.iteration_result = {}
+    g.hash:insert({1, "3"})
+    g.hash:insert({2, "2"})
+    g.hash:insert({3, "1"})
+
+    task = expirationd.start("clean_all", g.hash.id, helpers.is_expired_debug,
+            {iterator_type = "ALL", start_key = 2})
+    -- wait for tuples expired
+    helpers.retrying({}, function()
+        t.assert_equals(helpers.iteration_result, {
+            {3, "1"},
+            {2, "2"},
+            {1, "3"}
+        })
+    end)
+    task:kill()
+end
+
+function g.test_tree_index_eq()
+    for _, space in pairs({g.tree, g.vinyl}) do
+        -- without start key
+        helpers.iteration_result = {}
+        space:insert({1, "3"})
+        space:insert({2, "2"})
+        space:insert({3, "1"})
+
+        local task = expirationd.start("clean_all", space.id, helpers.is_expired_debug,
+                {iterator_type = "EQ"})
+        -- wait for tuples expired
+        helpers.retrying({}, function()
+            t.assert_equals(helpers.iteration_result, {
+                {1, "3"},
+                {2, "2"},
+                {3, "1"}
+            })
+        end)
+        task:kill()
+
+        -- with start_key
+        helpers.iteration_result = {}
+        space:insert({1, "1", nil, nil, 1})
+        space:insert({2, "2", nil, nil, 2})
+        space:insert({3, "3", nil, nil, 2})
+        space:insert({4, "4", nil, nil, 4})
+
+        task = expirationd.start("clean_all", space.id, helpers.is_expired_debug,
+                {iterator_type = "EQ", index = "non_unique_index", start_key = 2})
+        -- wait for tuples expired
+        helpers.retrying({}, function()
+            t.assert_equals(helpers.iteration_result, {
+                {2, "2", nil, nil, 2},
+                {3, "3", nil, nil, 2}
+            })
+        end)
+        task:kill()
+    end
+end
+
+function g.test_hash_index_eq()
+    -- iterator_type EQ with partial key (nil or {} is a partial key)
+    t.assert_error_msg_content_equals(
+            "HASH index  does not support selects via a partial key " ..
+            "(expected 1 parts, got 0). Please Consider changing index type to TREE.",
+            expirationd.start, "clean_all", g.hash.id, helpers.is_expired_true,
+            {iterator_type = "EQ"})
+
+    -- with start key
+    -- HASH doesn't support non unique indexes
+    helpers.iteration_result = {}
+    g.hash:insert({1, "3"})
+    g.hash:insert({2, "2"})
+    g.hash:insert({3, "1"})
+
+    local task = expirationd.start("clean_all", g.hash.id, helpers.is_expired_debug,
+            {iterator_type = "EQ", start_key = 2})
+    -- wait for tuples expired
+    helpers.retrying({}, function()
+        t.assert_equals(helpers.iteration_result, {
+            {2, "2"}
+        })
+    end)
+    task:kill()
+end
+
+function g.test_tree_index_gt()
+    for _, space in pairs({g.tree, g.vinyl}) do
+        -- without start key
+        helpers.iteration_result = {}
+        space:insert({1, "3"})
+        space:insert({2, "2"})
+        space:insert({3, "1"})
+
+        local task = expirationd.start("clean_all", space.id, helpers.is_expired_debug,
+                {iterator_type = "GT"})
+        -- wait for tuples expired
+        helpers.retrying({}, function()
+            t.assert_equals(helpers.iteration_result, {
+                {1, "3"},
+                {2, "2"},
+                {3, "1"}
+            })
+        end)
+        task:kill()
+
+        -- with start key
+        helpers.iteration_result = {}
+        space:insert({1, "3"})
+        space:insert({2, "2"})
+        space:insert({3, "1"})
+
+        task = expirationd.start("clean_all", space.id, helpers.is_expired_debug,
+                {iterator_type = "GT", start_key = 2})
+        -- wait for tuples expired
+        helpers.retrying({}, function()
+            t.assert_equals(helpers.iteration_result, {
+                {3, "1"}
+            })
+        end)
+        task:kill()
+    end
+end
+
+function g.test_hash_index_gt()
+    -- without start key
+    helpers.iteration_result = {}
+    g.hash:insert({1, "3"})
+    g.hash:insert({2, "2"})
+    g.hash:insert({3, "1"})
+
+    local task = expirationd.start("clean_all", g.hash.id, helpers.is_expired_debug,
+            {iterator_type = "GT"})
+    -- wait for tuples expired
+    helpers.retrying({}, function()
+        t.assert_equals(helpers.iteration_result, {
+            {3, "1"},
+            {2, "2"},
+            {1, "3"}
+        })
+    end)
+    task:kill()
+
+    -- with start key
+    -- will compare by hash
+    helpers.iteration_result = {}
+    g.hash:insert({1, "3"})
+    g.hash:insert({2, "2"})
+    g.hash:insert({3, "1"})
+
+    task = expirationd.start("clean_all", g.hash.id, helpers.is_expired_debug,
+            {iterator_type = "GT", start_key = 2})
+    -- wait for tuples expired
+    helpers.retrying({}, function()
+        t.assert_equals(helpers.iteration_result, {
+            {1, "3"},
+            {3, "1"}
+        })
+    end)
+    task:kill()
+end
+
+function g.test_tree_index_req()
+    for _, space in pairs({g.tree, g.vinyl}) do
+        -- without start key
+        helpers.iteration_result = {}
+        space:insert({1, "3"})
+        space:insert({2, "2"})
+        space:insert({3, "1"})
+
+        local task = expirationd.start("clean_all", space.id, helpers.is_expired_debug,
+                {iterator_type = "REQ"})
+        -- wait for tuples expired
+        helpers.retrying({}, function()
+            t.assert_equals(helpers.iteration_result, {
+                {3, "1"},
+                {2, "2"},
+                {1, "3"}
+            })
+        end)
+        task:kill()
+
+        -- with start_key
+        helpers.iteration_result = {}
+        space:insert({1, "1", nil, nil, 1})
+        space:insert({2, "2", nil, nil, 2})
+        space:insert({3, "3", nil, nil, 2})
+        space:insert({4, "4", nil, nil, 4})
+
+        task = expirationd.start("clean_all", space.id, helpers.is_expired_debug,
+                {iterator_type = "REQ", index = "non_unique_index", start_key = 2})
+        -- wait for tuples expired
+        helpers.retrying({}, function()
+            t.assert_equals(helpers.iteration_result, {
+                {3, "3", nil, nil, 2},
+                {2, "2", nil, nil, 2}
+            })
+        end)
+        task:kill()
+    end
+end
+
+function g.test_tree_index_ge()
+    for _, space in pairs({g.tree, g.vinyl}) do
+        -- without start key
+        helpers.iteration_result = {}
+        space:insert({1, "3"})
+        space:insert({2, "2"})
+        space:insert({3, "1"})
+
+        local task = expirationd.start("clean_all", space.id, helpers.is_expired_debug,
+                {iterator_type = "GE"})
+        -- wait for tuples expired
+        helpers.retrying({}, function()
+            t.assert_equals(helpers.iteration_result, {
+                {1, "3"},
+                {2, "2"},
+                {3, "1"}
+            })
+        end)
+        task:kill()
+
+        -- with start key
+        helpers.iteration_result = {}
+        space:insert({1, "3"})
+        space:insert({2, "2"})
+        space:insert({3, "1"})
+
+        task = expirationd.start("clean_all", space.id, helpers.is_expired_debug,
+                {iterator_type = "GE", start_key = 2})
+        -- wait for tuples expired
+        helpers.retrying({}, function()
+            t.assert_equals(helpers.iteration_result, {
+                {2, "2"},
+                {3, "1"}
+            })
+        end)
+        task:kill()
+    end
+end
+
+function g.test_tree_index_lt()
+    for _, space in pairs({g.tree, g.vinyl}) do
+        -- without start key
+        helpers.iteration_result = {}
+        space:insert({1, "3"})
+        space:insert({2, "2"})
+        space:insert({3, "1"})
+
+        local task = expirationd.start("clean_all", space.id, helpers.is_expired_debug,
+                {iterator_type = "LT"})
+        -- wait for tuples expired
+        helpers.retrying({}, function()
+            t.assert_equals(helpers.iteration_result, {
+                {3, "1"},
+                {2, "2"},
+                {1, "3"}
+            })
+        end)
+        task:kill()
+
+        -- with start key
+        helpers.iteration_result = {}
+        space:insert({1, "3"})
+        space:insert({2, "2"})
+        space:insert({3, "1"})
+
+        task = expirationd.start("clean_all", space.id, helpers.is_expired_debug,
+                {iterator_type = "LT", start_key = 2})
+        -- wait for tuples expired
+        helpers.retrying({}, function()
+            t.assert_equals(helpers.iteration_result, {
+                {1, "3"}
+            })
+        end)
+        task:kill()
+    end
+end
+
+function g.test_tree_index_le()
+    for _, space in pairs({g.tree, g.vinyl}) do
+        -- without start key
+        helpers.iteration_result = {}
+        space:insert({1, "3"})
+        space:insert({2, "2"})
+        space:insert({3, "1"})
+
+        local task = expirationd.start("clean_all", space.id, helpers.is_expired_debug,
+                {iterator_type = "LE"})
+        -- wait for tuples expired
+        helpers.retrying({}, function()
+            t.assert_equals(helpers.iteration_result, {
+                {3, "1"},
+                {2, "2"},
+                {1, "3"}
+            })
+        end)
+        task:kill()
+
+        -- with start key
+        helpers.iteration_result = {}
+        space:insert({1, "3"})
+        space:insert({2, "2"})
+        space:insert({3, "1"})
+
+        task = expirationd.start("clean_all", space.id, helpers.is_expired_debug,
+                {iterator_type = "LE", start_key = 2})
+        -- wait for tuples expired
+        helpers.retrying({}, function()
+            t.assert_equals(helpers.iteration_result, {
+                {2, "2"},
+                {1, "3"}
+            })
+        end)
+        task:kill()
+    end
+end

--- a/test/unit/process_while_test.lua
+++ b/test/unit/process_while_test.lua
@@ -1,0 +1,70 @@
+local expirationd = require("expirationd")
+local t = require("luatest")
+local g = t.group("process_while")
+
+local helpers = require("test.helper")
+
+g.before_all(function()
+    helpers.init_spaces(g)
+end)
+
+g.after_each(function()
+    helpers.truncate_spaces(g)
+end)
+
+function g.test_passing()
+    local task = expirationd.start("clean_all", g.tree.id, helpers.is_expired_true)
+    -- default process_while always return false, iterations never stopped by this function
+    t.assert_equals(task.process_while(), true)
+    task:kill()
+
+    local function process_while()
+        return false
+    end
+
+    task = expirationd.start("clean_all", g.tree.id, helpers.is_expired_true,
+            {process_while = process_while})
+    t.assert_equals(task.process_while(), false)
+    task:kill()
+
+    -- errors
+    t.assert_error_msg_content_equals("Invalid type of process_while, expected function",
+            expirationd.start, "clean_all", g.tree.id, helpers.is_expired_true,
+            { process_while = "" })
+end
+
+local function process_while(task)
+    if task.checked_tuples_count >= 1 then return false end
+    return true
+end
+
+function g.test_tree_index()
+    for _, space in pairs({g.tree, g.vinyl}) do
+        helpers.iteration_result = {}
+        space:insert({1, "3"})
+        space:insert({2, "2"})
+        space:insert({3, "1"})
+        local task = expirationd.start("clean_all", space.id, helpers.is_expired_debug,
+                {process_while = process_while})
+        -- wait for tuples expired
+        helpers.retrying({}, function()
+            t.assert_equals(helpers.iteration_result, {{1, "3"}})
+        end)
+        task:kill()
+    end
+end
+
+function g.test_hash_index()
+    helpers.iteration_result = {}
+    g.hash:insert({1, "3"})
+    g.hash:insert({2, "2"})
+    g.hash:insert({3, "1"})
+
+    local task = expirationd.start("clean_all", g.hash.id, helpers.is_expired_debug,
+            {process_while = process_while})
+    -- wait for tuples expired
+    helpers.retrying({}, function()
+        t.assert_equals(helpers.iteration_result, {{3, "1"}})
+    end)
+    task:kill()
+end

--- a/test/unit/start_key_test.lua
+++ b/test/unit/start_key_test.lua
@@ -1,0 +1,165 @@
+local expirationd = require("expirationd")
+local t = require("luatest")
+local g = t.group("start_key")
+
+local helpers = require("test.helper")
+
+g.before_all(function()
+    helpers.init_spaces(g)
+end)
+
+g.after_each(function()
+    helpers.truncate_spaces(g)
+end)
+
+function g.test_passing()
+    local task = expirationd.start("clean_all", g.tree.id, helpers.is_expired_true)
+    -- default start element is nil, iterate all elements
+    t.assert_equals(task.start_key(), nil)
+    task:kill()
+
+    task = expirationd.start("clean_all", g.tree.id, helpers.is_expired_true,
+            {start_key = box.NULL})
+    -- default start element is nil, iterate all elements
+    t.assert_equals(task.start_key(), box.NULL)
+    task:kill()
+
+    task = expirationd.start("clean_all", g.tree.id, helpers.is_expired_true,
+            {start_key = 1})
+    t.assert_equals(task.start_key(), 1)
+    task:kill()
+
+    task = expirationd.start("clean_all", g.tree.id, helpers.is_expired_true,
+            { index = "multipart_index", start_key = {1, 1}})
+    t.assert_equals(task.start_key(), {1, 1})
+    task:kill()
+
+    -- errors
+    t.assert_error_msg_content_equals(
+            "Supplied key type of part 0 does not match index part type: expected number",
+            expirationd.start, "clean_all", g.tree.id, helpers.is_expired_true,
+            { start_key = "" })
+    t.assert_error_msg_content_equals(
+            "Supplied key type of part 0 does not match index part type: expected number",
+            expirationd.start, "clean_all", g.tree.id, helpers.is_expired_true,
+            { index = "multipart_index", start_key = "" })
+    t.assert_error_msg_content_equals(
+            "Supplied key type of part 0 does not match index part type: expected number",
+            expirationd.start, "clean_all", g.tree.id, helpers.is_expired_true,
+            { index = "multipart_index", start_key = {"", ""} })
+    t.assert_error_msg_content_equals(
+            "Supplied key type of part 1 does not match index part type: expected number",
+            expirationd.start, "clean_all", g.tree.id, helpers.is_expired_true,
+            { index = "multipart_index", start_key = {1, ""} })
+end
+
+function g.test_tree_index()
+    for _, space in pairs({g.tree, g.vinyl}) do
+        -- without start key
+        helpers.iteration_result = {}
+        space:insert({1, "3"})
+        space:insert({2, "2"})
+        space:insert({3, "1"})
+
+        local task = expirationd.start("clean_all", space.id, helpers.is_expired_debug)
+        -- wait for tuples expired
+        helpers.retrying({}, function()
+            t.assert_equals(helpers.iteration_result, {
+                {1, "3"},
+                {2, "2"},
+                {3, "1"}
+            })
+        end)
+        task:kill()
+
+        -- box.NULL
+        helpers.iteration_result = {}
+        space:insert({1, "3"})
+        space:insert({2, "2"})
+        space:insert({3, "1"})
+
+        task = expirationd.start("clean_all", space.id, helpers.is_expired_debug,
+                        {start_key = box.NULL})
+        -- wait for tuples expired
+        helpers.retrying({}, function()
+            t.assert_equals(helpers.iteration_result, {
+                {1, "3"},
+                {2, "2"},
+                {3, "1"}
+            })
+        end)
+        task:kill()
+
+        -- with start key
+        helpers.iteration_result = {}
+        space:insert({1, "3"})
+        space:insert({2, "2"})
+        space:insert({3, "1"})
+
+        task = expirationd.start("clean_all", space.id, helpers.is_expired_debug,
+                {start_key = 2})
+        -- wait for tuples expired
+        helpers.retrying({}, function()
+            t.assert_equals(helpers.iteration_result, {
+                {2, "2"},
+                {3, "1"}
+            })
+        end)
+        task:kill()
+    end
+end
+
+function g.test_hash_index()
+    -- without start key
+    helpers.iteration_result = {}
+    g.hash:insert({1, "3"})
+    g.hash:insert({2, "2"})
+    g.hash:insert({3, "1"})
+
+    local task = expirationd.start("clean_all", g.hash.id, helpers.is_expired_debug)
+    -- wait for tuples expired
+    helpers.retrying({}, function()
+        t.assert_equals(helpers.iteration_result, {
+            {3, "1"},
+            {2, "2"},
+            {1, "3"}
+        })
+    end)
+    task:kill()
+
+    -- box.NULL
+    helpers.iteration_result = {}
+    g.hash:insert({1, "3"})
+    g.hash:insert({2, "2"})
+    g.hash:insert({3, "1"})
+
+    task = expirationd.start("clean_all", g.hash.id, helpers.is_expired_debug,
+            {start_key = box.NULL})
+    -- wait for tuples expired
+    helpers.retrying({}, function()
+        t.assert_equals(helpers.iteration_result, {
+            {3, "1"},
+            {2, "2"},
+            {1, "3"}
+        })
+    end)
+    task:kill()
+
+    -- with start key
+    helpers.iteration_result = {}
+    g.hash:insert({1, "3"})
+    g.hash:insert({2, "2"})
+    g.hash:insert({3, "1"})
+
+    task = expirationd.start("clean_all", g.hash.id, helpers.is_expired_debug,
+            {start_key = 2})
+    -- wait for tuples expired
+    helpers.retrying({}, function()
+        t.assert_equals(helpers.iteration_result, {
+            {3, "1"},
+            {2, "2"},
+            {1, "3"}
+        })
+    end)
+    task:kill()
+end


### PR DESCRIPTION
* Iterations over Secondary Indexes - name of the index to iterate on
* Transaction support - ability to process tuples from each batch in a single transaction
* Start key - start iterating from the tuple with this index value
* Iterator type - type of the iterator to use, as string or box.index constant
* Process while function - function to call before checking each tuple, if it returns false, the task will stop until next full scan
* And the ability to write custom iterator behavior for the user - `iterate_with` function which returns an iterator object which provides tuples to check

Additional changes:
Rewritten space iteration for tree index from select to pairs since the iterator is now stable
Added some comments and removed duplicate code(expirationd_kill_task)
Described new parameters in the code

Test coverage added. 

RFC: #50 