### PR TITLE
Enable Lua source code analysis with luacheck

### DIFF
--- a/.github/workflows/fast_testing.yaml
+++ b/.github/workflows/fast_testing.yaml
@@ -40,11 +40,14 @@ jobs:
         id: cache-rocks
         with:
           path: .rocks/
-          key: cache-rocks-${{ matrix.tarantool }}-01
+          key: cache-rocks-${{ matrix.tarantool }}-02
 
       - name: Install requirements
         run: |
           tarantoolctl rocks install luatest 0.5.0
+          tarantoolctl rocks install luacheck 0.26.0
         if: steps.cache-rocks.outputs.cache-hit != 'true'
+
+      - run: make check
 
       - run: make test

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,28 @@
+globals = {
+    "box",
+    "_TARANTOOL",
+}
+
+ignore = {
+    -- Unused argument <self>.
+    "212/self",
+    -- Redefining a local variable.
+    "411",
+    -- Shadowing a local variable.
+    "421",
+    -- Shadowing an upvalue.
+    "431",
+    -- Shadowing an upvalue argument.
+    "432",
+}
+
+include_files = {
+    '.luacheckrc',
+    '*.rockspec',
+    '**/*.lua',
+}
+
+exclude_files = {
+    '.rocks',
+    'test.lua',
+}

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
 all:
 	@echo "Only tests are available: make test"
 
+check: luacheck
+
+luacheck:
+	.rocks/bin/luacheck --config .luacheckrc --codes .
+
 .PHONY: test
 test:
 	.rocks/bin/luatest -v

--- a/expirationd.lua
+++ b/expirationd.lua
@@ -291,6 +291,7 @@ local function get_task(name)
 end
 
 -- default process_expired_tuple function
+-- luacheck: ignore unused args
 local function default_tuple_drop(space_id, args, tuple)
     box.space[space_id]:delete(construct_key(space_id, tuple))
 end
@@ -583,8 +584,8 @@ local function expirationd_task_stats(name)
         return get_task(name):statistics()
     end
     local retval = {}
-    for name, task in pairs(task_list) do
-        retval[name] = task:statistics()
+    for task_name, task in pairs(task_list) do
+        retval[task_name] = task:statistics()
     end
     return retval
 end
@@ -604,14 +605,14 @@ local function expirationd_update()
     local expd_prev = require("expirationd")
     table.clear(expd_prev)
     setmetatable(expd_prev, {
-        __index = function(name)
+        __index = function()
             error("Wait until update is done before using expirationd", 2)
         end
     })
     package.loaded["expirationd"] = nil
     local expd_new  = require("expirationd")
     local tmp_task_list = task_list; task_list = {}
-    for name, task in pairs(tmp_task_list) do
+    for _, task in pairs(tmp_task_list) do
         task:kill()
         expd_new.start(
             task.name, task.space_id,

--- a/test/unit/atomic_iteration_test.lua
+++ b/test/unit/atomic_iteration_test.lua
@@ -36,7 +36,7 @@ function g.test_memtx()
     local function f(iterator)
         local transaction = {}
         -- old / new_tuple is not passed for vinyl
-        for request_number, old_tuple, new_tuple, space_id in iterator() do
+        for _, old_tuple in iterator() do
             table.insert(transaction, old_tuple:totable())
         end
         table.insert(transactions, transaction)


### PR DESCRIPTION
Added luacheck config and fixed a number of luacheck warnings.
Tarantool's Lua style guide allows to ignore some luacheck warnings [1].
File with TAP tests added to ignore list because we plan to rewrite
these tests to luatest style, see [2].

1. https://www.tarantool.io/en/doc/latest/dev_guide/lua_style_guide/#luacheck
2. https://github.com/tarantool/expirationd/issues/61

Closes #57