### PR TITLE
WIP: Role

### DIFF
--- a/.github/workflows/fast_testing.yaml
+++ b/.github/workflows/fast_testing.yaml
@@ -44,8 +44,9 @@ jobs:
 
       - name: Install requirements
         run: |
-          tarantoolctl rocks install luatest 0.5.0
+          tarantoolctl rocks install luatest 0.5.1
           tarantoolctl rocks install luacheck 0.26.0
+          CMAKE_DUMMY_WEBUI=YES tarantoolctl rocks install cartridge 2.6.0
         if: steps.cache-rocks.outputs.cache-hit != 'true'
 
       - run: make check

--- a/cartridge/roles/expirationd.lua
+++ b/cartridge/roles/expirationd.lua
@@ -1,0 +1,27 @@
+local expirationd = require("expirationd")
+local vars = require("cartridge.vars").new("expirationd")
+
+local function init()
+    rawset(_G, "expirationd", expirationd)
+end
+
+local function stop()
+    for _, name in pairs(expirationd.tasks()) do
+        local task = expirationd.get_task(name)
+        task:kill()
+        -- save the state
+        local func, state, var = task:iterate_with()
+        local _, start_tuple = func(state, var)
+
+        vars[name] = start_tuple
+    end
+    rawset(_G, "expirationd", nil)
+end
+
+return {
+    role_name = "expirationd",
+    permanent = true,
+
+    init = init,
+    stop = stop
+}

--- a/test/entrypoint/srv_reload.lua
+++ b/test/entrypoint/srv_reload.lua
@@ -1,0 +1,48 @@
+#!/usr/bin/env tarantool
+
+require("strict").on()
+_G.is_initialized = function() return false end
+
+local log = require("log")
+local errors = require("errors")
+local cartridge = require("cartridge")
+errors.set_deprecation_handler(function(err)
+    log.error("%s", err)
+    os.exit(1)
+end)
+
+local roles_reload_allowed = nil
+if not os.getenv("TARANTOOL_FORBID_HOTRELOAD") then
+    roles_reload_allowed = true
+end
+
+package.preload["mymodule"] = function()
+    return {
+        role_name = "myrole",
+        validate_config = function()
+            return true
+        end,
+        init = function()
+            local alpha = box.schema.create_space("alpha")
+            alpha:create_index("pri")
+            local beta = box.schema.create_space("beta")
+            beta:create_index("pri")
+        end,
+        apply_config = function() end,
+        stop = function() end,
+    }
+end
+
+local ok, err = errors.pcall("CartridgeCfgError", cartridge.cfg, {
+    roles = {
+        "cartridge.roles.expirationd",
+        "mymodule",
+    },
+    roles_reload_allowed = roles_reload_allowed,
+})
+if not ok then
+    log.error("%s", err)
+    os.exit(1)
+end
+
+_G.is_initialized = cartridge.is_healthy

--- a/test/helper.lua
+++ b/test/helper.lua
@@ -1,7 +1,7 @@
 local t = require("luatest")
 local fio = require("fio")
 
-local helpers = require("luatest.helpers")
+local helpers = require("cartridge.test-helpers")
 
 t.before_suite(function()
     t.datadir = fio.tempdir()
@@ -107,6 +107,20 @@ helpers.iteration_result = {}
 function helpers.is_expired_debug(_, tuple)
     table.insert(helpers.iteration_result, tuple)
     return true
+end
+
+helpers.project_root = fio.dirname(debug.sourcedir())
+
+function helpers.entrypoint(name)
+    local path = fio.pathjoin(
+            helpers.project_root,
+            "test", "entrypoint",
+            string.format("%s.lua", name)
+    )
+    if not fio.path.exists(path) then
+        error(path .. ": no such entrypoint", 2)
+    end
+    return path
 end
 
 return helpers

--- a/test/integration/cartridge_role_test.lua
+++ b/test/integration/cartridge_role_test.lua
@@ -1,0 +1,127 @@
+local utils = require("cartridge.utils")
+local expirationd = require("expirationd")
+local fio = require("fio")
+local t = require("luatest")
+local g = t.group("cartridge_role")
+
+local helpers = require("test.helper")
+
+local function reload_myrole(fn)
+    -- For the sake of string.dump() function must have no upvalues.
+    -- https://www.lua.org/manual/5.1/manual.html#pdf-string.dump
+    utils.assert_upvalues(fn, {})
+
+    local ok, err = g.srv.net_box:eval([[
+        package.preload["mymodule"] = loadstring(...)
+        return require("cartridge.roles").reload()
+    ]], {string.dump(fn)})
+
+    t.assert_equals({ok, err}, {true, nil})
+end
+
+g.before_all(function()
+    g.cluster = helpers.Cluster:new({
+        datadir = fio.tempdir(),
+        server_command = helpers.entrypoint("srv_reload"),
+        replicasets = {{
+                           alias = "A",
+                           roles = {"myrole"},
+                           servers = 1,
+                       }},
+    })
+    g.srv = g.cluster:server("A-1")
+    g.cluster:start()
+end)
+
+g.after_all(function()
+    g.cluster:stop()
+    fio.rmtree(g.cluster.datadir)
+end)
+
+function g.test_enabled_service()
+    local role_name = g.srv.net_box:eval([[
+        local cartridge = require("cartridge")
+        local expirationd = cartridge.service_get("expirationd")
+        return expirationd.role_name
+    ]])
+    t.assert_equals(role_name, "expirationd")
+end
+
+function g.test_with_start_key_state()
+    reload_myrole(function()
+        return {
+            role_name = "myrole",
+            init = function()
+                -- start tasks
+                local expirationd = require("expirationd")
+                local helpers = require("test.helper")
+                local count_of_tuples = 1024 * 100
+
+                for i = 1,count_of_tuples do
+                    box.space.alpha:insert({i, tostring(i)})
+                    box.space.beta:insert({i, tostring(i)})
+                end
+                expirationd.start("alpha", box.space.alpha.id, helpers.is_expired_debug,{
+                    force = true,
+                    iterator_type = box.index.LE
+                })
+                expirationd.start("beta", box.space.beta.id, helpers.is_expired_debug,{
+                    force = true,
+                    iterator_type = box.index.LE
+                })
+                return true
+            end,
+            stop = function() end
+        }
+    end)
+
+    reload_myrole(function()
+        return {
+            role_name = "myrole",
+            init = function()
+                local expirationd = require("expirationd")
+                local helpers = require("test.helper")
+                local t = require("luatest")
+
+                local count_of_tuples = 1024 * 100
+                local counters = {}
+                -- we use _G._cluster_vars_values cause cartridge.vars
+                -- does not allow us to go over the entire table,
+                -- maybe it is worth making a ticket in cartridge
+                for task_name, start_tuple in pairs(_G._cluster_vars_values.expirationd) do
+                    _G._cluster_vars_values.expirationd[task_name] = nil
+                    local count = box.space[task_name]:count()
+                    counters[task_name] = count
+
+                    -- save count to use in future asserts
+                    local first_tuple = box.space[task_name]:select(nil, {limit = 1, iterator = box.index.LE})[1]
+
+                    -- get start key from previous expiration daemon task
+                    local start_key = start_tuple[1]
+                    -- check some number of tuples removed
+                    t.assert(count > 0)
+                    t.assert(count < count_of_tuples)
+                    -- and check that the smallest tuple
+                    -- is the last tuple that was not removed by the last expiration
+                    t.assert_equals(first_tuple[1], start_key)
+
+                    -- start a new task from tuple the previous task ended
+                    expirationd.start(task_name, box.space[task_name].id, helpers.is_expired_debug,  {
+                        force = true,
+                        iterator_type = box.index.LE,
+                        start_key = start_key
+                    })
+                end
+                rawset(_G, "counters", counters)
+            end,
+            stop = function() end
+        }
+    end)
+
+    -- check the task really works and it's deleting some data
+    for _, name in pairs(expirationd.tasks()) do
+        local old_count = g.srv.net_box:eval("return counters[...]", name)
+        local count = g.srv.net_box:eval("return box.space[...]:count()", name)
+        t.assert(old_count > count)
+    end
+end


### PR DESCRIPTION
Role to support saving the expirationd tasks state in the form of start_key, a key that was not expired before the task was turned off. This key can be obtained to the user using cartridge.vars, as shown in the test.