### PR TITLE
Fix freezes when stopping a task

### DIFF
--- a/test/unit/task_stop_test.lua
+++ b/test/unit/task_stop_test.lua
@@ -1,0 +1,34 @@
+local expirationd = require("expirationd")
+local fiber = require("fiber")
+local t = require("luatest")
+local g = t.group("task_stop")
+
+local helpers = require("test.helper")
+
+g.before_all(function()
+    helpers.init_spaces(g)
+end)
+
+g.after_each(function()
+    helpers.truncate_spaces(g)
+end)
+
+function g.test_cancel_on_pcall()
+    local function on_full_scan_complete()
+        pcall(fiber.sleep, 1)
+    end
+    local one_hour = 3600
+    local task = expirationd.start("clean_all", g.tree.id, helpers.is_expired_true, {
+        full_scan_delay = one_hour,
+        on_full_scan_complete = on_full_scan_complete
+    })
+    helpers.retrying({}, function()
+        t.assert(task.worker_fiber)
+    end)
+    -- We need to execute in a separate fiber,
+    -- since pcall does not check testcancel and stop may freeze up.
+    local f = fiber.create(task.stop, task)
+    helpers.retrying({timeout = 5}, function()
+        t.assert_equals(f:status(), "dead")
+    end)
+end


### PR DESCRIPTION
The problem is that the call to task:stop hangs, because task:stop
sends cancel to the active fibers and waits for these fibers to become
"dead". But there may be some code that can get cancelation using pcall
and skip it, so we have to check the fiber for cancellation.
We do this by checking a flag `worker_canceled` that was previously
only used for atomic iterations. We also fixed the places where this
flag is checked and added comments why in this or that place we
check the cancellation of the worker.

Closes #69