### PR TITLE
ci: add reusable testing workflow

### DIFF
--- a/.github/workflows/reusable_testing.yml
+++ b/.github/workflows/reusable_testing.yml
@@ -1,0 +1,33 @@
+name: reusable_testing
+
+on:
+  workflow_call:
+    inputs:
+      artifact_name:
+        description: The name of the Tarantool build artifact
+        default: ubuntu-focal
+        required: false
+        type: string
+
+jobs:
+  run_tests:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Clone the expirationd module
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ github.repository_owner }}/expirationd
+
+      - name: Download the Tarantool build artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ inputs.artifact_name }}
+
+      - name: Install Tarantool
+        # Now we're lucky: all dependencies are already installed. Check package
+        # dependencies when migrating to other OS version.
+        run: sudo dpkg -i tarantool_*.deb tarantool-common_*.deb tarantool-dev_*.deb
+
+      - run: make deps
+      - run: echo $PWD/.rocks/bin >> $GITHUB_PATH
+      - run: make test


### PR DESCRIPTION
The idea of this workflow is to be a part of the 'integration.yml'
workflow from the tarantool repo to verify the integration of the
expirationd module with an arbitrary tarantool version.

This workflow is not triggered on a push to the repo and cannot be run
manually since it has only the 'workflow_call' trigger. This workflow
will be included in the tarantool development cycle and called by the
'integration.yml' workflow from the tarantool project on a push to the
master and release branches for verifying integration of tarantool with
expirationd.

Part of tarantool/tarantool#6528
Part of tarantool/tarantool#5265
Part of tarantool/tarantool#6056

Workflow on Tarantool side: https://github.com/tarantool/tarantool/pull/6529