### PR TITLE
Publish API documentation in Github Actions

### DIFF
--- a/.github/workflows/fast_testing.yaml
+++ b/.github/workflows/fast_testing.yaml
@@ -47,12 +47,7 @@ jobs:
           key: cache-rocks-${{ matrix.tarantool }}-06
 
       - name: Install requirements
-        run: |
-          tarantoolctl rocks install luatest 0.5.0
-          tarantoolctl rocks install luacheck 0.26.0
-          tarantoolctl rocks install luacov 0.13.0-1
-          tarantoolctl rocks install luacov-coveralls 0.2.3-1 --server=http://luarocks.org
-          tarantoolctl rocks make
+        run: make deps
         if: steps.cache-rocks.outputs.cache-hit != 'true'
 
       - run: echo $PWD/.rocks/bin >> $GITHUB_PATH

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
     tags: ['*']
 
 jobs:
-  publish-scm-1:
+  publish-rockspec-scm-1:
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
@@ -16,7 +16,7 @@ jobs:
           auth: ${{ secrets.ROCKS_AUTH }}
           files: expirationd-scm-1.rockspec
 
-  publish-tag:
+  publish-rockspec-tag:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
@@ -58,3 +58,37 @@ jobs:
           files: |
             expirationd-${{ env.TAG }}-1.rockspec
             expirationd-${{ env.TAG }}-1.all.rock
+
+  publish-ldoc:
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Tarantool
+        uses: tarantool/setup-tarantool@v1
+        with:
+          tarantool-version: 2.8
+
+      - name: Clone the module
+        uses: actions/checkout@v2
+
+      - name: Cache rocks
+        uses: actions/cache@v2
+        id: cache-rocks
+        with:
+          path: .rocks/
+          key: cache-rocks-${{ matrix.tarantool }}-01
+
+      - name: Install requirements
+        run: make deps
+        if: steps.cache-rocks.outputs.cache-hit != 'true'
+
+      - run: echo $PWD/.rocks/bin >> $GITHUB_PATH
+
+      - name: Build API documentation with LDoc
+        run: make apidoc
+
+      - name: Publish generated API documentation to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@4.1.4
+        with:
+          branch: gh-pages
+          folder: doc/apidoc

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ VERSION
 luacov.stats.out
 luacov.report.out
 tags
+.rocks
+doc/apidoc/
+*.swp

--- a/Makefile
+++ b/Makefile
@@ -52,5 +52,13 @@ coveralls: $(LUACOV_STATS)
 	echo "Send code coverage data to the coveralls.io service"
 	luacov-coveralls --include ^expirationd --verbose --repo-token ${GITHUB_TOKEN}
 
+deps:
+	tarantoolctl rocks install luatest 0.5.0
+	tarantoolctl rocks install luacheck 0.26.0
+	tarantoolctl rocks install luacov 0.13.0-1
+	tarantoolctl rocks install ldoc --server=https://tarantool.github.io/LDoc/
+	tarantoolctl rocks install luacov-coveralls 0.2.3-1 --server=http://luarocks.org
+	tarantoolctl rocks make
+
 clean:
 	rm -rf ${CLEANUP_FILES}


### PR DESCRIPTION
Follows up #79 

I check publishing in a separate branch [gh-79-publish-ldoc-test](https://github.com/tarantool/expirationd/commits/ligurio/gh-79-publish-ldoc-test) that contains a visible change in documentation ("Hello, dude!"):
```
--- a/expirationd.lua
+++ b/expirationd.lua
@@ -1,4 +1,4 @@
---- expirationd - data expiration with custom quirks.
+--- expirationd - data expiration with custom quirks (Hello, dude!).
 --
 -- @module expirationd
 ```

And also [removes things that blocks workflow run and uploading rock to the server](https://github.com/tarantool/expirationd/commit/8d7baec73bc4cfdae8d102670dbaf75ade680226).

https://tarantool.github.io/expirationd/

![Screenshot from 2021-10-21 21-17-41](https://user-images.githubusercontent.com/1151557/138334467-dbbc8436-db29-4768-b667-5183dd564e57.png)
