### PR TITLE
test: disable test_mvcc_vinyl_tx_conflict

### DIFF
--- a/test/helper.lua
+++ b/test/helper.lua
@@ -200,7 +200,8 @@ t.before_suite(function()
         memtx_dir  = t.datadir,
         vinyl_dir  = t.datadir,
         -- vinyl_memory is changed to test test_mvcc_vinyl_tx_conflict.
-        vinyl_memory = 1024,
+        -- TODO: Commented out until tarantool/expirationd#105 is resolved.
+        -- vinyl_memory = 1024,
     }
 
     local tree_code = [[function(tuple)

--- a/test/unit/atomic_iteration_test.lua
+++ b/test/unit/atomic_iteration_test.lua
@@ -134,6 +134,8 @@ end
 -- just check expirationd task continue work after conflicts
 function g.test_mvcc_vinyl_tx_conflict(cg)
     t.skip_if(cg.params.engine ~= 'vinyl', 'Unsupported engine')
+    -- TODO: Remove the line below when tarantool/expirationd#105 is resolved.
+    t.skip('Skipped until tarantool/expirationd#105 is resolved')
 
     for i = 1,10 do
         cg.space:insert({i, tostring(i), nil, nil, 0})


### PR DESCRIPTION
Let's disable the 'test_mvcc_vinyl_tx_conflict' test due to #105.
The test is unstable and should be reworked.