### PR TITLE
Prevent iteration through a functional index for Tarantool < 2.8.4

### DIFF
--- a/test/helper.lua
+++ b/test/helper.lua
@@ -262,4 +262,12 @@ function helpers.vinyl_is_broken()
     return broken_v1_10 or broken_v2
 end
 
+function helpers.memtx_func_index_is_broken()
+    local major, minor, patch = helpers.tarantool_version()
+    if major > 2 or (major == 2 and minor == 8 and patch >= 4) or (major == 2 and minor >= 10) then
+        return false
+    end
+    return true
+end
+
 return helpers


### PR DESCRIPTION
expirationd.start fails with an error for a functional index if
a Tarantool instance version is less than 2.8.4. It can be disabled
using options.force_allow_functional_index.

Closes #101

An user can use options.force_broken + options.iterate_with to avoid the crash, see:
https://github.com/tarantool/expirationd/blob/a2bc3d39ea20197818170da1886adfdd3de4cfac/test/unit/custom_index_test.lua#L239-L245
