### PR TITLE
Fix a description and behavior of the force option for expirationd.start

### DIFF
--- a/expirationd.lua
+++ b/expirationd.lua
@@ -148,7 +148,8 @@ local function worker_loop(task)
     fiber.name(string.format("worker of %q", task.name), { truncate = true })
 
     while true do
-        if (box.cfg.replication_source == nil and box.cfg.replication == nil) or task.force then
+        local replication = box.cfg.replication_source or box.cfg.replication
+        if replication == nil or #replication == 0 or task.force then
             task.on_full_scan_start(task)
             local state, err = pcall(task.do_worker_iteration, task)
             -- Following functions are on_full_scan*,

--- a/expirationd.lua
+++ b/expirationd.lua
@@ -415,6 +415,8 @@ end
 --
 -- 5. Repeat 1-4.
 --
+-- NOTE: By default expirationd does not start tasks on an instance with
+-- configured upstreams, see the `force` option.
 --
 -- @string name
 --     Task name.
@@ -445,12 +447,12 @@ end
 --     False (default) to process each tuple as a single transaction and true
 --     to process tuples from each batch in a single transaction.
 -- @boolean[opt] options.force
---     By default expirationd should process tasks only on the writeable
---     instance, it means that expirationd will not start task processing on a
---     replica. Here the word 'replica' means an instance with at least one
---     configured upstream, it's an option `box.cfg.replication_source`
---     (`box.cfg.replication` for Tarantool 1.7.6+). The option `force` let a
---     user control where to start task processing and where don't.
+--     By default expirationd does not start task processing on an instance with
+--     configured upstreams (see [`box.cfg.replication`][1]). Set the option
+--     to `true` to enable task processing on the instance.
+--
+--     [1]: https://www.tarantool.io/en/doc/latest/reference/configuration/#cfg-replication-replication.
+--
 -- @boolean[opt] options.force_allow_functional_index
 --     By default expirationd returns an error on iteration through a functional
 --     index for Tarantool < 2.8.4 because it may cause a crash, see


### PR DESCRIPTION
The pull request fixes the description and behavior of `force` option for `expirationd.start`. It just closes actual problems, synchronizes the description and current logic. It does not change an old behavior.

It was a fix for #95, but the small piece code is connected with an other unresolved issue. It closes #92, #95, #96. The changes is very simple, but I can split the pull request if necessary.