### PR TITLE
Add metrics for expirationd stats

### DIFF
--- a/.github/workflows/fast_testing.yaml
+++ b/.github/workflows/fast_testing.yaml
@@ -24,17 +24,33 @@ jobs:
           - '2.6'
           - '2.7'
           - '2.8'
+          - '2.10'
+        metrics-version:
+          - ''
+          - '0.10.0'
+          - '0.11.0'
+          - '0.13.0'
         coveralls: [false]
         include:
-          - tarantool: '2.8'
+          - tarantool: '2.10'
+            metrics-version: '0.13.0'
             coveralls: true
 
     runs-on: ubuntu-latest
     steps:
-      - name: Install tarantool ${{ matrix.tarantool }}
+      - name: Install tarantool ${{ matrix.tarantool }} (< 2.10)
+        if: matrix.tarantool != '2.10'
         uses: tarantool/setup-tarantool@v1
         with:
           tarantool-version: ${{ matrix.tarantool }}
+
+      # It's a temporary hack. May be removed after the fix:
+      # https://github.com/tarantool/setup-tarantool/issues/19
+      - name: Install tarantool ${{ matrix.tarantool }} (2.10)
+        if: matrix.tarantool == '2.10'
+        run: |
+          curl -L https://tarantool.io/tWsLBdI/release/2/installer.sh | bash
+          sudo apt install -y tarantool tarantool-dev
 
       - name: Clone the module
         uses: actions/checkout@v2
@@ -49,6 +65,12 @@ jobs:
       - name: Install requirements
         run: make deps
         if: steps.cache-rocks.outputs.cache-hit != 'true'
+
+      - name: Install cartridge and metrics
+        if: matrix.metrics-version != ''
+        run: |
+          tarantoolctl rocks install cartridge 2.7.4
+          tarantoolctl rocks install metrics ${{ matrix.metrics-version }}
 
       - run: echo $PWD/.rocks/bin >> $GITHUB_PATH
 

--- a/Makefile
+++ b/Makefile
@@ -60,5 +60,9 @@ deps:
 	tarantoolctl rocks install luacov-coveralls 0.2.3-1 --server=http://luarocks.org
 	tarantoolctl rocks make
 
+deps-full: deps
+	tarantoolctl rocks install cartridge 2.7.4
+	tarantoolctl rocks install metrics 0.13.0
+
 clean:
 	rm -rf ${CLEANUP_FILES}

--- a/README.md
+++ b/README.md
@@ -131,6 +131,6 @@ expirationd.start(job_name, space.id, is_expired, {
 ## Testing
 
 ```
-$ make deps
+$ make deps-full
 $ make test
 ```

--- a/expirationd.lua
+++ b/expirationd.lua
@@ -451,7 +451,7 @@ end
 --     configured upstreams (see [`box.cfg.replication`][1]). Set the option
 --     to `true` to enable task processing on the instance.
 --
---     [1]: https://www.tarantool.io/en/doc/latest/reference/configuration/#cfg-replication-replication.
+--     [1]: https://www.tarantool.io/en/doc/latest/reference/configuration/#cfg-replication-replication
 --
 -- @boolean[opt] options.force_allow_functional_index
 --     By default expirationd returns an error on iteration through a functional

--- a/test/entrypoint/srv_reload.lua
+++ b/test/entrypoint/srv_reload.lua
@@ -1,0 +1,49 @@
+#!/usr/bin/env tarantool
+
+require('strict').on()
+_G.is_initialized = function() return false end
+
+local log = require('log')
+local errors = require('errors')
+local cartridge = require('cartridge')
+
+package.preload['customers-storage'] = function()
+    return {
+        role_name = 'customers-storage',
+        init = function()
+            local customers_space = box.schema.space.create('customers', {
+                format = {
+                    {name = 'id', type = 'unsigned'},
+                },
+                if_not_exists = true,
+                engine = 'memtx',
+            })
+
+            customers_space:create_index('id', {
+                parts = { {field = 'id'} },
+                unique = true,
+                type = 'TREE',
+                if_not_exists = true,
+            })
+        end,
+    }
+end
+
+local ok, err = errors.pcall('CartridgeCfgError', cartridge.cfg, {
+    advertise_uri = 'localhost:3301',
+    http_port = 8081,
+    bucket_count = 3000,
+    roles = {
+        'customers-storage',
+        'cartridge.roles.vshard-router',
+        'cartridge.roles.vshard-storage',
+    },
+    roles_reload_allowed = true
+})
+
+if not ok then
+    log.error('%s', err)
+    os.exit(1)
+end
+
+_G.is_initialized = cartridge.is_healthy

--- a/test/helper.lua
+++ b/test/helper.lua
@@ -3,6 +3,8 @@ local fio = require("fio")
 
 local helpers = require("luatest.helpers")
 
+helpers.project_root = fio.dirname(debug.sourcedir())
+
 local function create_space(space_name, engine)
     local space_format = {
         {
@@ -221,6 +223,16 @@ end)
 
 function helpers.is_expired_true()
     return true
+end
+
+function helpers.is_metrics_supported()
+    local is_package, metrics = pcall(require, "metrics")
+    if not is_package then
+        return false
+    end
+    -- metrics >= 0.11.0 is required
+    local counter = require('metrics.collectors.counter')
+    return metrics.unregister_callback and counter.remove
 end
 
 function helpers.iterate_with_func(task)

--- a/test/integration/reload_test.lua
+++ b/test/integration/reload_test.lua
@@ -1,0 +1,121 @@
+local fio = require('fio')
+local t = require('luatest')
+local helpers = require('test.helper')
+local g = t.group('expirationd_reload')
+local is_cartridge_helpers, cartridge_helpers = pcall(require, 'cartridge.test-helpers')
+
+g.before_all(function(cg)
+    if is_cartridge_helpers then
+        local entrypoint_path = fio.pathjoin(helpers.project_root,
+                                             'test',
+                                             'entrypoint',
+                                             'srv_reload.lua')
+        cg.cluster = cartridge_helpers.Cluster:new({
+            datadir = fio.tempdir(),
+            server_command = entrypoint_path,
+            use_vshard = true,
+            replicasets = {
+                {
+                    uuid = helpers.uuid('a'),
+                    alias = 'router',
+                    roles = { 'vshard-router' },
+                    servers = {
+                        { instance_uuid = helpers.uuid('a', 1), alias = 'router' },
+                    },
+                },
+                {
+                    uuid = helpers.uuid('b'),
+                    alias = 's-1',
+                    roles = { 'vshard-storage', 'customers-storage' },
+                    servers = {
+                        { instance_uuid = helpers.uuid('b', 1), alias = 's1-master' },
+                    }
+                }
+            },
+        })
+        cg.cluster:start()
+    end
+end)
+
+g.after_all(function(cg)
+    if is_cartridge_helpers then
+        cg.cluster:stop()
+        fio.rmtree(cg.cluster.datadir)
+    end
+end)
+
+g.before_each(function()
+    t.skip_if(not is_cartridge_helpers, "cartridge is not installed")
+    t.skip_if(not helpers.is_metrics_supported(),
+              "metrics >= 0.11.0 is not installed")
+end)
+
+
+local function reload_roles(srv)
+    local ok, err = srv.net_box:eval([[
+        return require('cartridge.roles').reload()
+    ]])
+
+    t.assert_equals({ok, err}, {true, nil})
+end
+
+function g.test_cfg_metrics_disable_after_reload(cg)
+    cg.cluster:server('router').net_box:eval([[
+        local expirationd = require('expirationd')
+        expirationd.cfg({metrics = false})
+    ]])
+
+    reload_roles(cg.cluster:server('router'))
+
+    local ret = cg.cluster:server('router').net_box:eval([[
+        return require('expirationd').cfg.metrics
+    ]])
+    t.assert_equals(ret, false)
+end
+
+function g.test_cfg_metrics_enable_after_reload(cg)
+    cg.cluster:server('router').net_box:eval([[
+        local expirationd = require('expirationd')
+        expirationd.cfg({metrics = true})
+    ]])
+
+    reload_roles(cg.cluster:server('router'))
+
+    local ret = cg.cluster:server('router').net_box:eval([[
+        return require('expirationd').cfg.metrics
+    ]])
+    t.assert_equals(ret, true)
+end
+
+function g.test_cfg_metrics_clean_after_reload(cg)
+    local metrics = cg.cluster:server('s1-master').net_box:eval([[
+        local metrics = require('metrics')
+        local expirationd = require('expirationd')
+
+        expirationd.cfg({metrics = true})
+        expirationd.start("stats_basic", 'customers',
+                          function()
+                              return true
+                          end)
+        metrics.invoke_callbacks()
+        return metrics.collect()
+    ]])
+    local restarts = nil
+    for _, v in ipairs(metrics) do
+        if v.metric_name == "expirationd_restarts" then
+            restarts = v.value
+        end
+    end
+    t.assert_equals(restarts, 1)
+
+    reload_roles(cg.cluster:server('s1-master'))
+
+    local metrics = cg.cluster:server('s1-master').net_box:eval([[
+        local metrics = require('metrics')
+        local expirationd = require('expirationd')
+
+        metrics.invoke_callbacks()
+        return metrics.collect()
+    ]])
+    t.assert_equals(metrics, {})
+end

--- a/test/unit/cfg_test.lua
+++ b/test/unit/cfg_test.lua
@@ -1,0 +1,54 @@
+local expirationd = require("expirationd")
+local t = require("luatest")
+local helpers = require("test.helper")
+local g = t.group('expirationd_cfg')
+
+local metrics_required_msg = "metrics >= 0.11.0 is not installed"
+local metrics_not_required_msg = "metrics >= 0.11.0 is installed"
+
+function g.test_cfg_default_if_installed()
+    t.skip_if(not helpers.is_metrics_supported(), metrics_required_msg)
+    t.assert_equals(expirationd.cfg.metrics, true)
+end
+
+function g.test_cfg_default_if_uninstalled()
+    t.skip_if(helpers.is_metrics_supported(), metrics_not_required_msg)
+    t.assert_equals(expirationd.cfg.metrics, false)
+end
+
+function g.test_cfg_newindex()
+    t.assert_error_msg_content_equals("Use expirationd.cfg{} instead",
+                                      function()
+                                          expirationd.cfg.any_key = false
+                                      end)
+end
+
+function g.test_cfg_metrics_set_unset()
+    t.skip_if(not helpers.is_metrics_supported(), metrics_required_msg)
+
+    expirationd.cfg({metrics = true})
+    t.assert_equals(expirationd.cfg.metrics, true)
+    expirationd.cfg({metrics = false})
+    t.assert_equals(expirationd.cfg.metrics, false)
+end
+
+function g.test_cfg_metrics_multiple_set_unset()
+    t.skip_if(not helpers.is_metrics_supported(), metrics_required_msg)
+
+    expirationd.cfg({metrics = true})
+    expirationd.cfg({metrics = true})
+    t.assert_equals(expirationd.cfg.metrics, true)
+    expirationd.cfg({metrics = false})
+    expirationd.cfg({metrics = false})
+    t.assert_equals(expirationd.cfg.metrics, false)
+end
+
+function g.test_cfg_metrics_set_unsupported()
+    t.skip_if(helpers.is_metrics_supported(), metrics_not_required_msg)
+
+    t.assert_error_msg_content_equals("metrics >= 0.11.0 is required",
+                                      function()
+                                          expirationd.cfg({metrics = true})
+                                      end)
+    t.assert_equals(expirationd.cfg.metrics, false)
+end

--- a/test/unit/metrics_test.lua
+++ b/test/unit/metrics_test.lua
@@ -1,0 +1,264 @@
+local expirationd = require("expirationd")
+local t = require("luatest")
+local helpers = require("test.helper")
+local g = t.group('expirationd_metrics')
+
+g.before_each(function()
+    t.skip_if(not helpers.is_metrics_supported(),
+              "metrics >= 0.11.0 is not installed")
+    g.space = helpers.create_space_with_tree_index('memtx')
+end)
+
+local task = nil
+g.after_each(function(g)
+    expirationd.cfg({metrics = false})
+    require('metrics').clear()
+    g.space:drop()
+    if task ~= nil then
+        task:kill()
+        task = nil
+    end
+end)
+
+local function get_metrics()
+    local metrics = require('metrics')
+    metrics.invoke_callbacks()
+    return metrics.collect()
+end
+
+local function assert_metrics_equals(t, value, expected)
+    local copy = table.deepcopy(value)
+    for _, v in ipairs(copy) do
+         v['timestamp'] = nil
+    end
+    t.assert_items_equals(copy, expected)
+end
+
+local function assert_metrics_restarts_equals(t, value, expected)
+    local copy = {}
+    for _, v in ipairs(value) do
+        if v['metric_name'] == "expirationd_restarts" then
+            table.insert(copy, v)
+        end
+    end
+    assert_metrics_equals(t, copy, expected)
+end
+
+function g.test_metrics_disabled(cg)
+    expirationd.cfg({metrics = false})
+    task = expirationd.start("stats_basic", cg.space.id, helpers.is_expired_true)
+
+    local metrics = get_metrics()
+
+    assert_metrics_equals(t, metrics, {})
+    task:kill()
+    task = nil
+end
+
+local metrics_basic = {
+    {
+        label_pairs = {name = "stats_basic"},
+        metric_name = "expirationd_expired_count",
+        value = 0,
+    },
+    {
+        label_pairs = {name = "stats_basic"},
+        metric_name = "expirationd_checked_count",
+        value = 0,
+    },
+    {
+        label_pairs = {name = "stats_basic"},
+        metric_name = "expirationd_working_time",
+        value = 0,
+    },
+    {
+        label_pairs = {name = "stats_basic"},
+        metric_name = "expirationd_restarts",
+        value = 1,
+    },
+}
+
+function g.test_metrics_basic(cg)
+    expirationd.cfg({metrics = true})
+    task = expirationd.start("stats_basic", cg.space.id, helpers.is_expired_true)
+
+    local metrics = get_metrics()
+    assert_metrics_equals(t, metrics, metrics_basic)
+    task:kill()
+    task = nil
+end
+
+function g.test_metrics_no_values_after_kill(cg)
+    expirationd.cfg({metrics = true})
+    task = expirationd.start("stats_basic", cg.space.id, helpers.is_expired_true)
+
+    local metrics = get_metrics()
+    assert_metrics_equals(t, metrics, metrics_basic)
+
+    task:kill()
+    task = nil
+
+    local metrics = get_metrics()
+    assert_metrics_equals(t, metrics, {})
+end
+
+function g.test_metrics_multiple_tasks_and_kill(cg)
+    expirationd.cfg({metrics = true})
+    local task1 = expirationd.start("stats_basic1", cg.space.id, helpers.is_expired_true)
+    local task2 = expirationd.start("stats_basic2", cg.space.id, helpers.is_expired_true)
+    task2:restart()
+    local task3 = expirationd.start("stats_basic3", cg.space.id, helpers.is_expired_true)
+    task3:restart()
+    task3:restart()
+
+    local before_kill_metrics = get_metrics()
+
+    task1:kill()
+    local after1_kill_metrics = get_metrics()
+
+    task3:kill()
+    local after13_kill_metrics = get_metrics()
+
+    task2:kill()
+    local after123_kill_metrics = get_metrics()
+
+    assert_metrics_restarts_equals(t, before_kill_metrics, {
+        {
+            label_pairs = {name = "stats_basic1"},
+            metric_name = "expirationd_restarts",
+            value = 1,
+        },
+        {
+            label_pairs = {name = "stats_basic2"},
+            metric_name = "expirationd_restarts",
+            value = 2,
+        },
+        {
+            label_pairs = {name = "stats_basic3"},
+            metric_name = "expirationd_restarts",
+            value = 3,
+        },
+    })
+    assert_metrics_restarts_equals(t, after1_kill_metrics, {
+        {
+            label_pairs = {name = "stats_basic2"},
+            metric_name = "expirationd_restarts",
+            value = 2,
+        },
+        {
+            label_pairs = {name = "stats_basic3"},
+            metric_name = "expirationd_restarts",
+            value = 3,
+        },
+    })
+    assert_metrics_restarts_equals(t, after13_kill_metrics, {
+        {
+            label_pairs = {name = "stats_basic2"},
+            metric_name = "expirationd_restarts",
+            value = 2,
+        },
+    })
+    assert_metrics_restarts_equals(t, after123_kill_metrics, {})
+end
+
+function g.test_metrics_no_values_after_disable(cg)
+    expirationd.cfg({metrics = true})
+    task = expirationd.start("stats_basic", cg.space.id, helpers.is_expired_true)
+
+    local metrics = get_metrics()
+    assert_metrics_equals(t, metrics, metrics_basic)
+
+    expirationd.cfg({metrics = false})
+    local metrics = get_metrics()
+
+    assert_metrics_equals(t, metrics, {})
+    task:kill()
+    task = nil
+end
+
+function g.test_metrics_new_values_after_restart(cg)
+    expirationd.cfg({metrics = true})
+    task = expirationd.start("stats_basic", cg.space.id, helpers.is_expired_true)
+    task:restart()
+
+    local metrics = get_metrics()
+    assert_metrics_equals(t, metrics, {
+        {
+            label_pairs = {name = "stats_basic"},
+            metric_name = "expirationd_expired_count",
+            value = 0,
+        },
+        {
+            label_pairs = {name = "stats_basic"},
+            metric_name = "expirationd_checked_count",
+            value = 0,
+        },
+        {
+            label_pairs = {name = "stats_basic"},
+            metric_name = "expirationd_working_time",
+            value = 0,
+        },
+        {
+            label_pairs = {name = "stats_basic"},
+            metric_name = "expirationd_restarts",
+            value = 2,
+        }
+    })
+
+    task:kill()
+    local metrics = get_metrics()
+    assert_metrics_equals(t, metrics, {})
+
+    task = expirationd.start("stats_basic", cg.space.id, helpers.is_expired_true)
+    local metrics = get_metrics()
+    assert_metrics_equals(t, metrics, metrics_basic)
+
+    task:kill()
+    task = nil
+end
+
+function g.test_metrics_expired_count(cg)
+    local iteration_result = {
+        {1, "a"},
+        {2, "b"},
+        {3, "c"},
+    }
+
+    helpers.iteration_result = {}
+    cg.space:insert({1, "a"})
+    cg.space:insert({2, "b"})
+    cg.space:insert({3, "c"})
+
+    expirationd.cfg({metrics = true})
+    task = expirationd.start("stats_expired_count", cg.space.id, helpers.is_expired_debug)
+    helpers.retrying({}, function()
+        t.assert_equals(helpers.iteration_result, iteration_result)
+    end)
+
+    local metrics = get_metrics()
+    assert_metrics_equals(t, metrics, {
+        {
+            label_pairs = {name = "stats_expired_count"},
+            metric_name = "expirationd_expired_count",
+            value = 3,
+        },
+        {
+            label_pairs = {name = "stats_expired_count"},
+            metric_name = "expirationd_checked_count",
+            value = 3,
+        },
+        {
+            label_pairs = {name = "stats_expired_count"},
+            metric_name = "expirationd_working_time",
+            value = 0,
+        },
+        {
+            label_pairs = {name = "stats_expired_count"},
+            metric_name = "expirationd_restarts",
+            value = 1,
+        },
+    })
+
+    task:kill()
+    task = nil
+end


### PR DESCRIPTION
The patch adds the ability to export statistics to metrics >= 0.11.0. expirationd does not require the metrics package itself and tries to use an installed one.

It also adds a new API method expirationd.cfg({options}).

Closes #100 