### PR TITLE
ci: use setup-tarantool for 2.10

### DIFF
--- a/.github/workflows/fast_testing.yaml
+++ b/.github/workflows/fast_testing.yaml
@@ -38,19 +38,10 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - name: Install tarantool ${{ matrix.tarantool }} (< 2.10)
-        if: matrix.tarantool != '2.10'
+      - name: Install tarantool ${{ matrix.tarantool }}
         uses: tarantool/setup-tarantool@v1
         with:
           tarantool-version: ${{ matrix.tarantool }}
-
-      # It's a temporary hack. May be removed after the fix:
-      # https://github.com/tarantool/setup-tarantool/issues/19
-      - name: Install tarantool ${{ matrix.tarantool }} (2.10)
-        if: matrix.tarantool == '2.10'
-        run: |
-          curl -L https://tarantool.io/tWsLBdI/release/2/installer.sh | bash
-          sudo apt install -y tarantool tarantool-dev
 
       - name: Clone the module
         uses: actions/checkout@v2


### PR DESCRIPTION
Now the workaround for https://github.com/tarantool/setup-tarantool/issues/19 is not needed, because tarantool-2.10+ releases are supported since setup-tarantool v1.3.0.

The action uses the GitHub's caching infrastructure to speed up tarantool installation.