### PR TITLE
ci: add a debug Tarantool build

### DIFF
--- a/.github/workflows/fast_testing.yaml
+++ b/.github/workflows/fast_testing.yaml
@@ -25,6 +25,8 @@ jobs:
           - '2.7'
           - '2.8'
           - '2.10'
+        cartridge-version:
+          - '2.7.4'
         metrics-version:
           - ''
           - '0.10.0'
@@ -33,6 +35,7 @@ jobs:
         coveralls: [false]
         include:
           - tarantool: '2.10'
+            cartridge-version: '2.7.4'
             metrics-version: '0.13.0'
             coveralls: true
 
@@ -51,7 +54,9 @@ jobs:
         id: cache-rocks
         with:
           path: .rocks/
-          key: cache-rocks-${{ matrix.tarantool }}-07
+          key: "cache-rocks-${{ matrix.tarantool }}-\
+            ${{ matrix.cartridge-version }}-\
+            ${{ matrix.metrics-version }}"
 
       - name: Install requirements
         run: make deps
@@ -60,7 +65,7 @@ jobs:
       - name: Install cartridge and metrics
         if: matrix.metrics-version != ''
         run: |
-          tarantoolctl rocks install cartridge 2.7.4
+          tarantoolctl rocks install cartridge ${{ matrix.cartridge-version }}
           tarantoolctl rocks install metrics ${{ matrix.metrics-version }}
 
       - run: echo $PWD/.rocks/bin >> $GITHUB_PATH

--- a/.github/workflows/fast_testing.yaml
+++ b/.github/workflows/fast_testing.yaml
@@ -44,10 +44,10 @@ jobs:
           tarantool-version: ${{ matrix.tarantool }}
 
       - name: Clone the module
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Cache rocks
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache-rocks
         with:
           path: .rocks/

--- a/.github/workflows/fast_testing.yaml
+++ b/.github/workflows/fast_testing.yaml
@@ -25,6 +25,7 @@ jobs:
           - '2.7'
           - '2.8'
           - '2.10'
+          - 'debug-master'
         cartridge-version:
           - '2.7.4'
         metrics-version:
@@ -39,12 +40,61 @@ jobs:
             metrics-version: '0.13.0'
             coveralls: true
 
+    env:
+      TNT_DEBUG_PATH: /home/runner/tnt-debug
+
     runs-on: ubuntu-latest
     steps:
       - name: Install tarantool ${{ matrix.tarantool }}
+        if: startsWith(matrix.tarantool, 'debug') != true
         uses: tarantool/setup-tarantool@v1
         with:
           tarantool-version: ${{ matrix.tarantool }}
+
+      - name: Create variables for Tarantool ${{ matrix.tarantool }}
+        if: startsWith(matrix.tarantool, 'debug')
+        run: |
+          branch=$(echo ${{ matrix.tarantool }} | cut -d- -f2)
+          commit_hash=$(git ls-remote https://github.com/tarantool/tarantool.git --branch ${branch} | head -c 8)
+          echo "TNT_BRANCH=${branch}" >> $GITHUB_ENV
+          echo "VERSION_POSTFIX=-${commit_hash}" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Cache tarantool build
+        if: startsWith(matrix.tarantool, 'debug')
+        id: cache-tnt-debug
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.TNT_DEBUG_PATH }}
+          key: cache-tnt-${{ matrix.tarantool }}${{ env.VERSION_POSTFIX }}
+
+      - name: Clone tarantool ${{ matrix.tarantool }}
+        if: startsWith(matrix.tarantool, 'debug') && steps.cache-tnt-debug.outputs.cache-hit != 'true'
+        uses: actions/checkout@v3
+        with:
+          repository: tarantool/tarantool
+          ref: ${{ env.TNT_BRANCH }}
+          path: tarantool
+          fetch-depth: 0
+          submodules: true
+
+      - name: Build tarantool ${{ matrix.tarantool }}
+        if: startsWith(matrix.tarantool, 'debug') && steps.cache-tnt-debug.outputs.cache-hit != 'true'
+        run: |
+          sudo apt-get -y install git build-essential cmake make zlib1g-dev \
+            libreadline-dev libncurses5-dev libssl-dev \
+            libunwind-dev libicu-dev python3 python3-yaml \
+            python3-six python3-gevent
+          cd ${GITHUB_WORKSPACE}/tarantool
+          mkdir build && cd build
+          cmake .. -DCMAKE_BUILD_TYPE=Debug -DENABLE_DIST=ON
+          make
+          make DESTDIR=${TNT_DEBUG_PATH} install
+
+      - name: Install tarantool ${{ matrix.tarantool }}
+        if: startsWith(matrix.tarantool, 'debug')
+        run: |
+          sudo cp -rvP ${TNT_DEBUG_PATH}/usr/local/* /usr/local/
 
       - name: Clone the module
         uses: actions/checkout@v3
@@ -54,7 +104,7 @@ jobs:
         id: cache-rocks
         with:
           path: .rocks/
-          key: "cache-rocks-${{ matrix.tarantool }}-\
+          key: "cache-rocks-${{ matrix.tarantool }}${{ env.VERSION_POSTFIX }}-\
             ${{ matrix.cartridge-version }}-\
             ${{ matrix.metrics-version }}"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: tarantool/rocks.tarantool.org/github-action@master
         with:
           auth: ${{ secrets.ROCKS_AUTH }}
@@ -20,7 +20,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Create a rockspec for the release.
       - run: printf '%s=%s\n' TAG "${GITHUB_REF##*/}" >> "${GITHUB_ENV}"
@@ -69,10 +69,10 @@ jobs:
           tarantool-version: 2.8
 
       - name: Clone the module
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Cache rocks
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache-rocks
         with:
           path: .rocks/

--- a/.github/workflows/reusable_testing.yml
+++ b/.github/workflows/reusable_testing.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Clone the expirationd module
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ github.repository_owner }}/expirationd
 
       - name: Download the Tarantool build artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: ${{ inputs.artifact_name }}
 


### PR DESCRIPTION
The patch adds a Tarantool debug build from the last commit of the master branch to GitHub Actions workflow. It uses an official build instruction for Tarantool [1] and the cache action [2] to cache build outputs.
    
1. https://www.tarantool.io/ru/doc/latest/dev_guide/building_from_source/
2. https://github.com/actions/cache
    
Closes #102