### PR TITLE
repo: take maintairnership

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: tarantool-expirationd
 Priority: optional
 Section: database
-Maintainer: Sergey Bronnikov <sergeyb@tarantool.org>
+Maintainer: Oleg Jukovec <oleg.jukovec@tarantool.org>
 Build-Depends: debhelper (>= 9),
                tarantool (>= 1.6.8.0),
 # For /usr/bin/prove

--- a/expirationd-scm-1.rockspec
+++ b/expirationd-scm-1.rockspec
@@ -8,7 +8,7 @@ description = {
     summary = "Expiration daemon for Tarantool",
     homepage = "https://github.com/tarantool/expirationd",
     license = "BSD2",
-    maintainer = "Sergey Bronnikov <sergeyb@tarantool.org>"
+    maintainer = "Oleg Jukovec <oleg.jukovec@tarantool.org>"
 }
 dependencies = {
     "lua >= 5.1", -- actually tarantool > 1.6


### PR DESCRIPTION
The patch updates the maintainer's name and email address for a rockspec and a debian package.

A previous one: https://github.com/tarantool/expirationd/commit/135f033bd09bafc7a9621a26e301b67ea9820cd6