### PR TITLE
api: continue a task from a last tuple

### DIFF
--- a/test/integration/reload_test.lua
+++ b/test/integration/reload_test.lua
@@ -46,10 +46,13 @@ end)
 
 g.before_each(function()
     t.skip_if(not is_cartridge_helpers, "cartridge is not installed")
-    t.skip_if(not helpers.is_metrics_supported(),
-              "metrics >= 0.11.0 is not installed")
 end)
 
+g.after_each(function()
+    g.cluster:server('s1-master').net_box:eval([[
+        box.space.customers:truncate()
+    ]])
+end)
 
 local function reload_roles(srv)
     local ok, err = srv.net_box:eval([[
@@ -59,7 +62,102 @@ local function reload_roles(srv)
     t.assert_equals({ok, err}, {true, nil})
 end
 
+local walk_task_name = "walk_all"
+local task_sleep_on_10_eval = string.format([[
+    local expirationd = require('expirationd')
+    local fiber = require("fiber")
+    local helpers = require("test.helper")
+
+    for i = 1,100 do
+        box.space.customers:insert({i})
+    end
+
+    local tuples_cnt = 0
+    local is_expired_sleep = function()
+        tuples_cnt = tuples_cnt + 1
+        if tuples_cnt == 10 then
+            fiber.sleep(60)
+        end
+        return true
+    end
+    task = expirationd.start("%s", box.space.customers.id, is_expired_sleep,
+                             {process_expired_tuple = function() return true end,
+                              force = true})
+
+    helpers.retrying({}, function()
+        if tuples_cnt < 10 then
+            error("the task do not reach a target tuple")
+        end
+    end)
+]], walk_task_name)
+
+local task_first_tuple_eval = string.format([[
+    local expirationd = require('expirationd')
+    local helpers = require("test.helper")
+
+    local tuple = nil
+    local is_expired_tuple = function(arg, t)
+        if tuple == nil then
+            tuple = t
+        end
+        return true
+    end
+    task = expirationd.start("%s", box.space.customers.id, is_expired_tuple,
+                             {force = true})
+
+    helpers.retrying({}, function()
+        if tuple == nil then
+            error("the task is not started")
+        end
+    end)
+
+    task:kill()
+
+    return tuple or {}
+]], walk_task_name)
+
+function g.test_task_continue_after_reload(cg)
+    local ok = cg.cluster:server('s1-master').net_box:eval(task_sleep_on_10_eval .. [[
+        return true
+    ]])
+    t.assert_equals(ok, true)
+
+    reload_roles(cg.cluster:server('s1-master'))
+
+    local tuple = cg.cluster:server('s1-master').net_box:eval(task_first_tuple_eval)
+    t.assert_equals(tuple, {10})
+end
+
+function g.test_task_continue_after_stop_and_reload(cg)
+    local ok = cg.cluster:server('s1-master').net_box:eval(task_sleep_on_10_eval .. [[
+        task:stop()
+        return true
+    ]])
+    t.assert_equals(ok, true)
+
+    reload_roles(cg.cluster:server('s1-master'))
+
+    local tuple = cg.cluster:server('s1-master').net_box:eval(task_first_tuple_eval)
+    t.assert_equals(tuple, {10})
+end
+
+function g.test_task_not_continue_after_kill_and_reload(cg)
+    local ok = cg.cluster:server('s1-master').net_box:eval(task_sleep_on_10_eval .. [[
+        task:kill()
+        return true
+    ]])
+    t.assert_equals(ok, true)
+
+    reload_roles(cg.cluster:server('s1-master'))
+
+    local tuple = cg.cluster:server('s1-master').net_box:eval(task_first_tuple_eval)
+    t.assert_equals(tuple, {1})
+end
+
 function g.test_cfg_metrics_disable_after_reload(cg)
+    t.skip_if(not helpers.is_metrics_supported(),
+              "metrics >= 0.11.0 is not installed")
+
     cg.cluster:server('router').net_box:eval([[
         local expirationd = require('expirationd')
         expirationd.cfg({metrics = false})
@@ -74,6 +172,9 @@ function g.test_cfg_metrics_disable_after_reload(cg)
 end
 
 function g.test_cfg_metrics_enable_after_reload(cg)
+    t.skip_if(not helpers.is_metrics_supported(),
+              "metrics >= 0.11.0 is not installed")
+
     cg.cluster:server('router').net_box:eval([[
         local expirationd = require('expirationd')
         expirationd.cfg({metrics = true})
@@ -88,6 +189,9 @@ function g.test_cfg_metrics_enable_after_reload(cg)
 end
 
 function g.test_cfg_metrics_clean_after_reload(cg)
+    t.skip_if(not helpers.is_metrics_supported(),
+              "metrics >= 0.11.0 is not installed")
+
     local metrics = cg.cluster:server('s1-master').net_box:eval([[
         local metrics = require('metrics')
         local expirationd = require('expirationd')

--- a/test/unit/continue_test.lua
+++ b/test/unit/continue_test.lua
@@ -1,0 +1,242 @@
+local expirationd = require("expirationd")
+local fiber = require("fiber")
+local t = require("luatest")
+local helpers = require("test.helper")
+local g = t.group('expirationd_continue')
+
+local task_name = "walk_all"
+g.before_each(function()
+    g.space = helpers.create_space_with_tree_index('memtx')
+    for _, task in ipairs(expirationd.tasks()) do
+         if task == task_name then
+             expirationd.task(task_name):kill()
+         end
+    end
+end)
+
+g.after_each(function()
+    g.space:drop()
+    if box.space.tmp ~= nil then
+        box.space.tmp:drop()
+    end
+end)
+
+local tuples_wait_event = {{1, "1"}, {2, "2"}, {3, "3"}, {4, "4"}, {5, "5"}}
+local tuples_all = {{1, "1"}, {2, "2"}, {3, "3"}, {4, "4"}, {5, "5"},
+                    {6, "6"}, {7, "7"}, {8, "8"}, {9, "9"}, {10, "10"}}
+local tuples_repeat = {{1, "1"}, {2, "2"}, {3, "3"}, {4, "4"}, {5, "5"},
+                       {1, "1"}, {2, "2"}, {3, "3"}, {4, "4"}, {5, "5"},
+                       {6, "6"}, {7, "7"}, {8, "8"}, {9, "9"}, {10, "10"}}
+
+local function insert_tuples(space)
+    for i = 1,10 do
+        space:insert({i, tostring(i)})
+    end
+end
+
+local function start_walk_task(space, sleep)
+    local cnt = 0
+    local is_expired = function(args, tuple)
+        cnt = cnt + 1
+        if cnt == 6 then
+            if sleep then
+                fiber.sleep(60)
+            else
+                error("test error in iteration")
+            end
+        end
+        return helpers.is_expired_debug(args, tuple)
+    end
+    local task = expirationd.start(task_name, space.id, is_expired,
+                                   {process_expired_tuple = function() return true end})
+    return task
+end
+
+function g.test_task_continue_after_error()
+    insert_tuples(g.space)
+
+    helpers.iteration_result = {}
+    local task = start_walk_task(g.space, false)
+    helpers.retrying({}, function()
+        t.assert_equals(helpers.iteration_result, tuples_wait_event)
+    end)
+
+    helpers.retrying({}, function()
+        t.assert_equals(helpers.iteration_result, tuples_all)
+    end)
+
+    task:kill()
+end
+
+function g.test_task_continue_after_stop_start()
+    insert_tuples(g.space)
+
+    helpers.iteration_result = {}
+    local task = start_walk_task(g.space, true)
+    helpers.retrying({}, function()
+        t.assert_equals(helpers.iteration_result, tuples_wait_event)
+    end)
+
+    task:stop()
+    task:start()
+
+    helpers.retrying({}, function()
+        t.assert_equals(helpers.iteration_result, tuples_all)
+    end)
+
+    task:kill()
+end
+
+function g.test_task_continue_after_stop_recreate()
+    insert_tuples(g.space)
+
+    helpers.iteration_result = {}
+    local task = start_walk_task(g.space, true)
+    helpers.retrying({}, function()
+        t.assert_equals(helpers.iteration_result, tuples_wait_event)
+    end)
+
+    task:stop()
+    local task = expirationd.start(task_name, g.space.id, helpers.is_expired_debug,
+                                   {process_expired_tuple = function() return true end})
+
+
+    helpers.retrying({}, function()
+        t.assert_equals(helpers.iteration_result, tuples_all)
+    end)
+
+    task:kill()
+end
+
+function g.test_task_not_continue_after_kill_start()
+    insert_tuples(g.space)
+
+    helpers.iteration_result = {}
+    local task = start_walk_task(g.space, true)
+    helpers.retrying({}, function()
+        t.assert_equals(helpers.iteration_result, tuples_wait_event)
+    end)
+
+    task:kill()
+
+    local task = expirationd.start(task_name, g.space.id, helpers.is_expired_debug,
+                                   {process_expired_tuple = function() return true end})
+    helpers.retrying({}, function()
+        t.assert_equals(helpers.iteration_result, tuples_repeat)
+    end)
+
+    task:kill()
+end
+
+function g.test_task_not_continue_after_restart()
+    insert_tuples(g.space)
+
+    helpers.iteration_result = {}
+    local task = start_walk_task(g.space, true)
+    helpers.retrying({}, function()
+        t.assert_equals(helpers.iteration_result, tuples_wait_event)
+    end)
+
+    task:restart()
+
+    helpers.retrying({}, function()
+        t.assert_equals(helpers.iteration_result, tuples_repeat)
+    end)
+
+    task:kill()
+end
+
+function g.test_task_not_continue_after_index_changed()
+    local space = box.schema.create_space("tmp")
+    local index = space:create_index("primary", {type = "TREE", parts = {{field = 1}}})
+    insert_tuples(space)
+
+    helpers.iteration_result = {}
+    local task = start_walk_task(space, false)
+    helpers.retrying({}, function()
+        t.assert_equals(helpers.iteration_result, tuples_wait_event)
+    end)
+
+    index:alter({parts = {{field = 2}}})
+
+    helpers.retrying({}, function()
+        t.assert_equals(helpers.iteration_result,
+                        {{1, "1"}, {2, "2"}, {3, "3"}, {4, "4"}, {5, "5"},
+                         {1, "1"}, {10, "10"}, {2, "2"}, {3, "3"}, {4, "4"},
+                         {5, "5"}, {6, "6"}, {7, "7"}, {8, "8"}, {9, "9"}})
+    end)
+
+    task:kill()
+    space:drop()
+end
+
+function g.test_task_not_continue_after_stop_recreate_other_space()
+    insert_tuples(g.space)
+    local space = box.schema.create_space("tmp")
+    space:create_index("primary", {type = "TREE", parts = {{field = 1}}})
+    insert_tuples(space)
+
+    helpers.iteration_result = {}
+    local task = start_walk_task(g.space, true)
+    helpers.retrying({}, function()
+        t.assert_equals(helpers.iteration_result, tuples_wait_event)
+    end)
+
+    task:stop()
+    local task = expirationd.start(task_name, space.id, helpers.is_expired_debug,
+                                   {process_expired_tuple = function() return true end})
+
+    helpers.retrying({}, function()
+        t.assert_equals(helpers.iteration_result, tuples_repeat)
+    end)
+
+    task:kill()
+    space:drop()
+end
+
+function g.test_task_not_continue_after_stop_recreate_other_index()
+    insert_tuples(g.space)
+
+    helpers.iteration_result = {}
+    local task = start_walk_task(g.space, true)
+    helpers.retrying({}, function()
+        t.assert_equals(helpers.iteration_result, tuples_wait_event)
+    end)
+
+    task:stop()
+    local task = expirationd.start(task_name, g.space.id, helpers.is_expired_debug,
+                                   {process_expired_tuple = function() return true end,
+                                    index = "index_for_first_name" })
+
+
+    helpers.retrying({}, function()
+        t.assert_equals(helpers.iteration_result,
+                        {{1, "1"}, {2, "2"}, {3, "3"}, {4, "4"}, {5, "5"},
+                         {1, "1"}, {10, "10"}, {2, "2"}, {3, "3"}, {4, "4"},
+                         {5, "5"}, {6, "6"}, {7, "7"}, {8, "8"}, {9, "9"}})
+    end)
+
+    task:kill()
+end
+
+function g.test_task_not_continue_after_stop_recreate_other_iterator()
+    insert_tuples(g.space)
+
+    helpers.iteration_result = {}
+    local task = start_walk_task(g.space, true)
+    helpers.retrying({}, function()
+        t.assert_equals(helpers.iteration_result, tuples_wait_event)
+    end)
+
+    task:stop()
+    local task = expirationd.start(task_name, g.space.id, helpers.is_expired_debug,
+                                   {process_expired_tuple = function() return true end,
+                                    iterator_type = box.index.GE})
+
+
+    helpers.retrying({}, function()
+        t.assert_equals(helpers.iteration_result, tuples_repeat)
+    end)
+
+    task:kill()
+end


### PR DESCRIPTION
After the patch a task continues processing from a last tuple at startup unless it was killed using `task:kill()` or `expirationd.kill()`. We cannot provide a safe behavior for all user cases, so it works only with default `start_key` and `iterate_with` callbacks.

The behavior supports a cartridge hot-reload.

Closes #54

A cartridge role is out of scope here and will be done for #107 . In the pull request just continue tasks + cartridge hot-reload tests for it.