### PR TITLE
cartridge: add a role

### DIFF
--- a/cartridge/roles/expirationd.lua
+++ b/cartridge/roles/expirationd.lua
@@ -1,0 +1,208 @@
+local expirationd = require("expirationd")
+local role_name = "expirationd"
+local started = require("cartridge.vars").new(role_name)
+
+local function load_function(func_name)
+    if func_name == nil or type(func_name) ~= 'string' then
+        return nil
+    end
+
+    local func = rawget(_G, func_name)
+    if func == nil or type(func) ~= 'function' then
+        return nil
+    end
+    return func
+end
+
+local function get_param(param_name, value, types)
+    local types_map = {
+        b = {type = "boolean", err = "a boolean"},
+        n = {type = "number", err = "a number"},
+        s = {type = "string", err = "a string"},
+        f = {type = "string", transform = load_function, err = "a function name in _G"},
+        t = {type = "table", err = "a table"},
+        any = {err = "any type"},
+    }
+
+    local found = false
+    for _, t in ipairs(types) do
+        local type_opts = types_map[t]
+        if type_opts == nil then
+            error(role_name .. ": unsupported type option")
+        end
+        if not type_opts.type or type(value) == type_opts.type then
+            if type_opts.transform then
+                local tmp = type_opts.transform(value)
+                if tmp then
+                    value = tmp
+                    found = true
+                    break
+                end
+            else
+                found = true
+                break
+            end
+        end
+    end
+
+    if not found then
+        local err = role_name .. ": " .. param_name .. " must be "
+        for i, t in ipairs(types) do
+            err = err .. types_map[t].err
+            if i ~= #types then
+                err = err .. " or "
+            end
+        end
+        return false, err
+    end
+    return true, value
+end
+
+local function get_task_options(opts)
+    local opts_map = {
+        args = {"any"},
+        atomic_iteration = {"b"},
+        force = {"b"},
+        force_allow_functional_index = {"b"},
+        full_scan_delay = {"n"},
+        full_scan_time = {"n"},
+        index = {"n", "s"},
+        iterate_with = {"f"},
+        iteration_delay = {"n"},
+        iterator_type = {"n", "s"},
+        on_full_scan_complete = {"f"},
+        on_full_scan_error = {"f"},
+        on_full_scan_start = {"f"},
+        on_full_scan_success = {"f"},
+        process_expired_tuple = {"f"},
+        process_while = {"f"},
+        start_key = {"f", "t"},
+        tuples_per_iteration = {"n"},
+        vinyl_assumed_space_len_factor = {"n"},
+        vinyl_assumed_space_len = {"n"},
+    }
+    if opts == nil then
+        return
+    end
+
+    for opt, val in pairs(opts) do
+        if type(opt) ~= "string" then
+            error(role_name .. ": an option must be a string")
+        end
+        if opts_map[opt] == nil then
+            error(role_name .. ": unsupported option '" .. opt .. "'")
+        end
+        local ok, res = get_param("options." .. opt, val, opts_map[opt])
+        if not ok then
+            error(res)
+        end
+        opts[opt] = res
+    end
+
+    return opts
+end
+
+local function get_task_config(task_conf)
+    -- setmetatable resets __newindex write protection on a copy
+    local conf = setmetatable(table.deepcopy(task_conf), {})
+    local params_map = {
+        space_id = {required = true, types = {"n", "s"}},
+        is_expired = {required = true, types = {"f"}},
+        is_master_only = {required = false, types = {"b"}},
+        options = {required = false, types = {"t"}},
+    }
+    for k, _ in pairs(conf) do
+        if type(k) ~= "string" then
+            error(role_name .. ": param must be a string")
+        end
+        if params_map[k] == nil then
+            error(role_name .. ": unsupported param " .. k)
+        end
+    end
+
+    for param, opts in pairs(params_map) do
+        if opts.required and conf[param] == nil then
+            error(role_name .. ": " .. param .. " is required")
+        end
+        if conf[param] ~= nil then
+            local ok, res = get_param(param, conf[param], opts.types)
+            if not ok then
+                error(res)
+            end
+            conf[param] = res
+        end
+    end
+
+    conf.options = get_task_options(conf.options)
+    return conf
+end
+
+local function init()
+
+end
+
+local function validate_config(conf_new)
+    local conf = conf_new[role_name] or {}
+
+    for task_name, task_conf in pairs(conf) do
+        local ok, res = get_param("task name", task_name, {"s"})
+        if not ok then
+            error(res)
+        end
+        local ok, res = get_param("task params", task_conf, {"t"})
+        if not ok then
+            error(res)
+        end
+        get_task_config(task_conf)
+    end
+
+    return true
+end
+
+local function apply_config(conf_new, opts)
+    local conf = conf_new[role_name] or {}
+
+    -- finishes tasks from an old configuration
+    for i=#started,1,-1 do
+        local task_name = started[i]
+        local ok, _ = pcall(expirationd.task, task_name)
+        if ok then
+            if conf[task_name] then
+                expirationd.task(task_name):stop()
+            else
+                expirationd.task(task_name):kill()
+            end
+        end
+        table.remove(started, i)
+    end
+
+    for task_name, task_conf in pairs(conf) do
+        task_conf = get_task_config(task_conf)
+
+        local skip = task_conf.is_master_only and not opts.is_master
+        if not skip then
+            local task = expirationd.start(task_name, task_conf.space_id,
+                                           task_conf.is_expired,
+                                           task_conf.options)
+            if task == nil then
+                error(role_name .. ": unable to start task " .. task_name)
+            end
+            table.insert(started, task_name)
+        end
+    end
+end
+
+local function stop()
+    for _, task_name in pairs(expirationd.tasks()) do
+        local task = expirationd.task(task_name)
+        task:stop()
+    end
+end
+
+return setmetatable({
+    role_name = role_name,
+    init = init,
+    validate_config = validate_config,
+    apply_config = apply_config,
+    stop = stop,
+}, { __index = expirationd })

--- a/debian/tarantool-expirationd.install
+++ b/debian/tarantool-expirationd.install
@@ -1,1 +1,2 @@
 expirationd.lua usr/share/tarantool/
+cartridge/roles/expirationd.lua usr/share/tarantool/cartridge/roles/

--- a/expirationd-scm-1.rockspec
+++ b/expirationd-scm-1.rockspec
@@ -18,6 +18,7 @@ build = {
     type = "builtin",
     modules = {
         ["expirationd"] = "expirationd.lua",
+        ["cartridge.roles.expirationd"] = "cartridge/roles/expirationd.lua",
     }
 }
 -- vim: syntax=lua

--- a/rpm/tarantool-expirationd.spec
+++ b/rpm/tarantool-expirationd.spec
@@ -27,9 +27,12 @@ some other space.
 %install
 install -d %{buildroot}%{_datarootdir}/tarantool/
 install -m 0644 expirationd.lua %{buildroot}%{_datarootdir}/tarantool/
+install -d %{buildroot}%{_datarootdir}/tarantool/cartridge/roles/
+install -m 0644 cartridge/roles/expirationd.lua %{buildroot}%{_datarootdir}/tarantool/cartridge/roles/expirationd.lua
 
 %files
 %{_datarootdir}/tarantool/expirationd.lua
+%{_datarootdir}/tarantool/cartridge
 %doc README.md
 %{!?_licensedir:%global license %doc}
 %license LICENSE

--- a/test/entrypoint/srv_role.lua
+++ b/test/entrypoint/srv_role.lua
@@ -1,0 +1,69 @@
+#!/usr/bin/env tarantool
+
+require('strict').on()
+_G.is_initialized = function() return false end
+
+local log = require('log')
+local errors = require('errors')
+local fiber = require('fiber')
+local cartridge = require('cartridge')
+local hotreload = require('cartridge.hotreload')
+
+package.preload['customers-storage'] = function()
+    return {
+        role_name = 'customers-storage',
+        init = function()
+            local customers_space = box.schema.space.create('customers', {
+                format = {
+                    {name = 'id', type = 'unsigned'},
+                },
+                if_not_exists = true,
+                engine = 'memtx',
+            })
+
+            customers_space:create_index('id', {
+                parts = { {field = 'id'} },
+                unique = true,
+                type = 'TREE',
+                if_not_exists = true,
+            })
+        end,
+    }
+end
+
+local ok, err = errors.pcall('CartridgeCfgError', cartridge.cfg, {
+    advertise_uri = 'localhost:3301',
+    http_port = 8081,
+    bucket_count = 3000,
+    roles = {
+        'customers-storage',
+        'cartridge.roles.vshard-router',
+        'cartridge.roles.vshard-storage',
+        'cartridge.roles.expirationd'
+    },
+    roles_reload_allowed = true,
+})
+
+if not ok then
+    log.error('%s', err)
+    os.exit(1)
+end
+
+_G.is_initialized = cartridge.is_healthy
+_G.always_true_test = function() return true end
+_G.is_expired_test_continue = function(_, tuple)
+    if rawget(_G, "is_expired_test_first_tuple") == nil then
+        rawset(_G, "is_expired_test_first_tuple", tuple)
+    end
+
+    local cnt = rawget(_G, "is_expired_test_wait_cnt") or 0
+    cnt = cnt + 1
+    rawset(_G, "is_expired_test_wait_cnt", cnt)
+    if cnt == 5 then
+        fiber.sleep(60)
+    end
+    return true
+end
+
+hotreload.whitelist_globals({"always_true_test"})
+hotreload.whitelist_globals({"is_expired_test_continue"})

--- a/test/integration/role_test.lua
+++ b/test/integration/role_test.lua
@@ -1,0 +1,161 @@
+local fio = require('fio')
+local t = require('luatest')
+local helpers = require('test.helper')
+local g = t.group('expirationd_intergration_role')
+local is_cartridge_helpers, cartridge_helpers = pcall(require, 'cartridge.test-helpers')
+
+g.before_all(function(cg)
+    if is_cartridge_helpers then
+        local entrypoint_path = fio.pathjoin(helpers.project_root,
+                                             'test',
+                                             'entrypoint',
+                                             'srv_role.lua')
+        cg.cluster = cartridge_helpers.Cluster:new({
+            datadir = fio.tempdir(),
+            server_command = entrypoint_path,
+            use_vshard = true,
+            replicasets = {
+                {
+                    uuid = helpers.uuid('a'),
+                    alias = 'router',
+                    roles = { 'vshard-router' },
+                    servers = {
+                        { instance_uuid = helpers.uuid('a', 1), alias = 'router' },
+                    },
+                },
+                {
+                    uuid = helpers.uuid('b'),
+                    alias = 's-1',
+                    roles = { 'vshard-storage', 'customers-storage', 'expirationd' },
+                    servers = {
+                        { instance_uuid = helpers.uuid('b', 1), alias = 's1-master' },
+                        { instance_uuid = helpers.uuid('b', 2), alias = 's1-slave' },
+                    }
+                }
+            },
+        })
+        cg.cluster:start()
+    end
+end)
+
+g.after_all(function(cg)
+    if is_cartridge_helpers then
+        cg.cluster:stop()
+        fio.rmtree(cg.cluster.datadir)
+    end
+end)
+
+g.before_each(function(cg)
+    t.skip_if(not is_cartridge_helpers, "cartridge is not installed")
+    cg.cluster.main_server:upload_config({})
+end)
+
+g.after_each(function(cg)
+    cg.cluster:server('s1-master').net_box:eval([[
+        box.space.customers:truncate()
+    ]])
+end)
+
+function g.test_expirationd_service_calls(cg)
+    local result, err = cg.cluster:server('s1-master').net_box:eval([[
+        local expirationd = require('expirationd')
+        local cartridge = require('cartridge')
+        local service = cartridge.service_get("expirationd")
+
+        for k, v in pairs(expirationd) do
+            if service[k] == nil then
+                return false
+            end
+        end
+        return true
+    ]])
+    t.assert_equals({result, err}, {true, nil})
+end
+
+-- init/stop/validate_config/apply_config well tested in test/unit/role_test.lua
+-- here we just ensure that it works as expected
+function g.test_start_task_from_config(cg)
+    t.assert_equals(3, cg.cluster:server('s1-master').net_box:eval([[
+        box.space.customers:insert({1})
+        box.space.customers:insert({2})
+        box.space.customers:insert({3})
+        return #box.space.customers:select({}, {limit = 10})
+    ]]))
+    cg.cluster.main_server:upload_config({
+        expirationd = {
+            test_task = {
+                space_id = "customers",
+                is_expired = "always_true_test",
+                is_master_only = true,
+            }
+        },
+    })
+    t.assert_equals(cg.cluster:server('s1-master').net_box:eval([[
+        local cartridge = require("cartridge")
+        return #cartridge.service_get("expirationd").tasks()
+    ]]), 1)
+    helpers.retrying({}, function()
+        t.assert_equals(cg.cluster:server('s1-master').net_box:eval([[
+            return #box.space.customers:select({}, {limit = 10})
+        ]]), 0)
+    end)
+
+    -- is_master == false
+    t.assert_equals(cg.cluster:server("s1-slave").net_box:eval([[
+        local cartridge = require("cartridge")
+        return #cartridge.service_get("expirationd").tasks()
+    ]]), 0)
+    helpers.retrying({}, function()
+        t.assert_equals(cg.cluster:server('s1-slave').net_box:eval([[
+            return #box.space.customers:select({}, {limit = 10})
+        ]]), 0)
+    end)
+end
+
+function g.test_continue_after_hotreload(cg)
+    t.assert_equals(10, cg.cluster:server('s1-master').net_box:eval([[
+        for i = 1,10 do
+            box.space.customers:insert({i})
+        end
+        return #box.space.customers:select({}, {limit = 20})
+    ]]))
+    cg.cluster.main_server:upload_config({
+        expirationd = {
+            test_task = {
+                space_id = "customers",
+                is_expired = "is_expired_test_continue",
+                is_master_only = true,
+                options = {
+                    process_expired_tuple = "always_true_test",
+                },
+            }
+        },
+    })
+
+    t.assert_equals(cg.cluster:server('s1-master').net_box:eval([[
+        local cartridge = require("cartridge")
+        return #cartridge.service_get("expirationd").tasks()
+    ]]), 1)
+    helpers.retrying({}, function()
+        t.assert_equals(cg.cluster:server('s1-master').net_box:eval([[
+            return _G.is_expired_test_first_tuple
+        ]]), {1})
+    end)
+
+    cg.cluster:server('s1-master').net_box:eval([[
+        return require('cartridge.roles').reload()
+    ]])
+
+    t.assert_equals(cg.cluster:server('s1-master').net_box:eval([[
+        local cartridge = require("cartridge")
+        return #cartridge.service_get("expirationd").tasks()
+    ]]), 1)
+    t.assert_equals(cg.cluster:server('s1-master').net_box:eval([[
+        return #box.space.customers:select({}, {limit = 20})
+    ]]), 10)
+    helpers.retrying({}, function()
+        t.assert_equals(cg.cluster:server('s1-master').net_box:eval([[
+            return _G.is_expired_test_first_tuple
+        ]]), {5})
+    end)
+end

--- a/test/unit/role_test.lua
+++ b/test/unit/role_test.lua
@@ -1,0 +1,698 @@
+local expirationd = require("expirationd")
+local fiber = require("fiber")
+local t = require("luatest")
+local helpers = require("test.helper")
+local g = t.group('expirationd_role')
+local is_cartridge_roles, _ = pcall(require, 'cartridge.roles')
+
+local always_true_func_name = "expirationd_test_always_true"
+local iterate_pairs_func_name = "expirationd_test_pairs"
+
+g.before_each(function()
+    t.skip_if(not is_cartridge_roles, "cartridge is not installed")
+
+    g.role = require("cartridge.roles.expirationd")
+    g.space = helpers.create_space_with_tree_index('memtx')
+
+    -- kill live tasks (it can still live after failed tests)
+    for _, t in ipairs(g.role.tasks()) do
+        g.role.kill(t)
+    end
+
+    rawset(_G, always_true_func_name, function() return true end)
+    rawset(_G, iterate_pairs_func_name, function() return pairs({}) end)
+end)
+
+g.after_each(function(g)
+    g.space:drop()
+    g.role.stop()
+    for _, t in ipairs(g.role.tasks()) do
+        g.role.kill(t)
+    end
+
+    rawset(_G, always_true_func_name, nil)
+    rawset(_G, iterate_pairs_func_name, nil)
+end)
+
+function g.test_expirationd_naming_no_role_intersections()
+    -- https://www.tarantool.io/ru/doc/latest/book/cartridge/cartridge_api/modules/custom-role/
+    for k, _ in pairs(expirationd) do
+         for _, reserved in ipairs({"init", "stop", "validate_config",
+                                    "apply_config", "get_issues",
+                                    "role_name", "hidden", "permanent",}) do
+            t.assert_not_equals(k, reserved)
+         end
+    end
+end
+
+function g.test_expirationd_export_all_to_role(cg)
+    for k, _ in pairs(expirationd) do
+         t.assert_not_equals(cg.role[k], nil)
+    end
+end
+
+function g.test_expirationd_task_in_role(cg)
+    local task_name = "test_task_expirationd"
+    local task = expirationd.start(task_name, cg.space.id, helpers.is_expired_debug, {})
+    t.assert_not_equals(task, nil)
+
+    t.assert_equals(#cg.role.tasks(), 1)
+    t.assert_not_equals(cg.role.task(task_name), nil)
+
+    task:kill()
+end
+
+function g.test_stop_all_tasks(cg)
+    local is_task_processes = function(name)
+        local prev_checked = cg.role.task(name):statistics().checked_count
+        local new_checked = nil
+        for _ = 1,100 do
+            new_checked = cg.role.task(name):statistics().checked_count
+            if new_checked ~= prev_checked then
+                break
+            end
+            fiber.yield()
+        end
+        return new_checked ~= prev_checked
+    end
+
+    cg.space:insert({1, "1"})
+    local opts = {
+        process_expired_tuple = function() return true end,
+        iteration_delay = 0,
+        full_scan_delay = 0,
+    }
+    local e_task = expirationd.start("e", cg.space.id, helpers.is_expired_debug, opts)
+    t.assert_not_equals(e_task, nil)
+    local r_task = cg.role.start("r", cg.space.id, helpers.is_expired_debug, opts)
+    t.assert_not_equals(r_task, nil)
+    t.assert_equals(is_task_processes("e"), true)
+    t.assert_equals(is_task_processes("r"), true)
+
+    cg.role.stop()
+
+    t.assert_equals(is_task_processes("e"), false)
+    t.assert_equals(is_task_processes("r"), false)
+
+    e_task:kill()
+    r_task:kill()
+end
+
+function g.test_validate_config_empty(cg)
+    t.assert_equals(cg.role.validate_config({}), true)
+    t.assert_equals(cg.role.validate_config({["expirationd"] = {}}), true)
+end
+
+local required_test_cases = {
+    all_ok_space_number = {
+        ok = true,
+        cfg = { ["task_name"] = {
+            space_id = 1,
+            is_expired = always_true_func_name,
+        }}
+    },
+    all_ok_space_string = {
+        ok = true,
+        cfg = { ["task_name"] = {
+            space_id = "space name",
+            is_expired = always_true_func_name,
+        }}
+    },
+    all_ok_empty_opts = {
+        ok = true,
+        cfg = { ["task_name"] = {
+            space_id = 1,
+            is_expired = always_true_func_name,
+            options = {}
+        }}
+    },
+    not_table = {
+        ok = false,
+        err = "expirationd: task params must be a table",
+        cfg = { ["task_name"] = 123 },
+    },
+    no_space = {
+        ok = false,
+        err = "expirationd: space_id is required",
+        cfg = { ["task_name"] = {
+            is_expired = always_true_func_name,
+        }}
+    },
+    no_expired = {
+        ok = false,
+        err = "expirationd: is_expired is required",
+        cfg = { ["task_name"] = {
+            space_id = 1,
+        }}
+    },
+    invalid_name = {
+        ok = false,
+        err = "expirationd: task name must be a string",
+        cfg = { [3] = {
+            space_id = "space name",
+            is_expired = always_true_func_name,
+        }}
+    },
+    invalid_space = {
+        ok = false,
+        err = "expirationd: space_id must be a number or a string",
+        cfg = { ["task_name"] = {
+            space_id = {},
+            is_expired = always_true_func_name,
+        }}
+    },
+    invalid_expired = {
+        ok = false,
+        err = "expirationd: is_expired must be a function name in _G",
+        cfg = { ["task_name"] = {
+            space_id = 1,
+            is_expired = 0,
+        }}
+    },
+    invalid_expired_func = {
+        ok = false,
+        err = "expirationd: is_expired must be a function name in _G",
+        cfg = { ["task_name"] = {
+            space_id = 1,
+            is_expired = "any invelid func name",
+        }}
+    },
+}
+
+for k, case in pairs(required_test_cases) do
+    g["test_validate_config_required_" .. k] = function(cg)
+        local status, res = pcall(cg.role.validate_config, {expirationd = case.cfg})
+        if case.ok then
+            t.assert_equals(status, true)
+            t.assert_equals(res, true)
+        else
+            t.assert_equals(status, false)
+            t.assert_str_contains(res, case.err)
+        end
+    end
+end
+
+local function create_valid_required(args)
+    local new_args = table.deepcopy(args)
+    new_args["space_id"] = 1
+    new_args["is_expired"] = always_true_func_name
+    return {expirationd = {["task_name"] = new_args}}
+end
+
+local additional_opts_test_cases = {
+   is_master_boolean = {
+        ok = true,
+        cfg = {is_master_only = true}
+   },
+   is_master_not_boolean = {
+        ok = false,
+        err = "expirationd: is_master_only must be a boolean",
+        cfg = {is_master_only = {}}
+   },
+}
+
+for k, case in pairs(additional_opts_test_cases) do
+    g["test_validate_config_additional_" .. k] = function(cg)
+        local cfg = create_valid_required(case.cfg)
+        local status, res = pcall(cg.role.validate_config, cfg)
+        if case.ok then
+            t.assert_equals(status, true)
+            t.assert_equals(res, true)
+        else
+            t.assert_equals(status, false)
+            t.assert_str_contains(res, case.err)
+        end
+    end
+end
+
+local options_cases = {
+    nilval = {
+        ok = true,
+        options = nil,
+    },
+    empty = {
+        ok = true,
+        options = {},
+    },
+    number = {
+        ok = false,
+        err = "expirationd: an option must be a string",
+        options = {[1] = "any"},
+    },
+    unsupported = {
+        ok = false,
+        err = "expirationd: unsupported option 'unsupported_option'",
+        options = {unsupported_option = "any"},
+    },
+    args_table = {
+        ok = true,
+        options = {args = {}},
+    },
+    args_string = {
+        ok = true,
+        options = {args = "string"},
+    },
+    args_number = {
+        ok = true,
+        options = {args = 13},
+    },
+    args_boolean = {
+        ok = true,
+        options = {args = true},
+    },
+    atomic_iteration_boolean = {
+        ok = true,
+        options = {atomic_iteration = true},
+    },
+    atomic_iteration_invalid = {
+        ok = false,
+        err = "expirationd: options.atomic_iteration must be a boolean",
+        options = {atomic_iteration = "string"},
+    },
+    force_boolean = {
+        ok = true,
+        options = {force = false},
+    },
+    force_invalid = {
+        ok = false,
+        err = "expirationd: options.force must be a boolean",
+        options = {force = "string"},
+    },
+    force_allow_functional_index_boolean = {
+        ok = true,
+        options = {force_allow_functional_index = true },
+    },
+    force_allow_functional_index_invalid = {
+        ok = false,
+        err = "expirationd: options.force_allow_functional_index must be a boolean",
+        options = {force_allow_functional_index = 13},
+    },
+    full_scan_delay_number = {
+        ok = true,
+        options = {full_scan_delay = 13},
+    },
+    full_scan_delay_invalid = {
+        ok = false,
+        err = "expirationd: options.full_scan_delay must be a number",
+        options = {full_scan_delay = "string"},
+    },
+    full_scan_time_number = {
+        ok = true,
+        options = {full_scan_time = 23},
+    },
+    full_scan_time_invalid = {
+        ok = false,
+        err = "expirationd: options.full_scan_time must be a number",
+        options = {full_scan_time = true},
+    },
+    index_number = {
+        ok = true,
+        options = {index = 0},
+    },
+    index_string = {
+        ok = true,
+        options = {index = "string"},
+    },
+    index_invalid = {
+        ok = false,
+        err = "expirationd: options.index must be a number or a string",
+        options = {index = true},
+    },
+    iterate_with_func = {
+        ok = true,
+        options = {iterate_with = always_true_func_name},
+    },
+    iterate_with_string = {
+        ok = false,
+        err = "expirationd: options.iterate_with must be a function name in _G",
+        options = {iterate_with = "any string"},
+    },
+    iterate_with_table = {
+        ok = false,
+        err = "expirationd: options.iterate_with must be a function name in _G",
+        options = {iterate_with = {}},
+    },
+    iteration_delay_number = {
+        ok = true,
+        options = {iteration_delay = 876},
+    },
+    iteration_delay_invalid = {
+        ok = false,
+        err = "expirationd: options.iteration_delay must be a number",
+        options = {iteration_delay = {"table"}},
+    },
+    iterator_type_number = {
+        ok = true,
+        options = {iterator_type = box.index.GE},
+    },
+    iterator_type_string = {
+        ok = true,
+        options = {iterator_type = "GE"},
+    },
+    iterator_type_invalid = {
+        ok = false,
+        err = "expirationd: options.iterator_type must be a number or a string",
+        options = {iterator_type = false},
+    },
+    on_full_scan_complete_func = {
+        ok = true,
+        options = {on_full_scan_complete = always_true_func_name},
+    },
+    on_full_scan_complete_string = {
+        ok = false,
+        err = "expirationd: options.on_full_scan_complete must be a function name in _G",
+        options = {on_full_scan_complete = "any string func"},
+    },
+    on_full_scan_error_func = {
+        ok = true,
+        options = {on_full_scan_error = always_true_func_name},
+    },
+    on_full_scan_error_string = {
+        ok = false,
+        err = "expirationd: options.on_full_scan_error must be a function name in _G",
+        options = {on_full_scan_error = "any string func"},
+    },
+    on_full_scan_start_func = {
+        ok = true,
+        options = {on_full_scan_start = always_true_func_name},
+    },
+    on_full_scan_start_string = {
+        ok = false,
+        err = "expirationd: options.on_full_scan_start must be a function name in _G",
+        options = {on_full_scan_start = "any string func"},
+    },
+    on_full_scan_success_func = {
+        ok = true,
+        options = {on_full_scan_success = always_true_func_name},
+    },
+    on_full_scan_success_string = {
+        ok = false,
+        err = "expirationd: options.on_full_scan_success must be a function name in _G",
+        options = {on_full_scan_success = "any string func"},
+    },
+    process_expired_tuple_func = {
+        ok = true,
+        options = {process_expired_tuple = always_true_func_name},
+    },
+    process_expired_tuple_string = {
+        ok = false,
+        err = "expirationd: options.process_expired_tuple must be a function name in _G",
+        options = {process_expired_tuple = "any string func"},
+    },
+    process_while_func = {
+        ok = true,
+        options = {process_while = always_true_func_name},
+    },
+    process_while_string = {
+        ok = false,
+        err = "expirationd: options.process_while must be a function name in _G",
+        options = {process_while = "any string func"},
+    },
+    start_key_func = {
+        ok = true,
+        options = {start_key = always_true_func_name},
+    },
+    start_key_table = {
+        ok = true,
+        options = {start_key = {1, 2, 3}},
+    },
+    start_key_invalid = {
+        ok = false,
+        err = "expirationd: options.start_key must be a function name in _G or a table",
+        options = {start_key = "any string"},
+    },
+    tuples_per_iteration_number = {
+        ok = true,
+        options = {tuples_per_iteration = 11},
+    },
+    tuples_per_iteration_invalid = {
+        ok = false,
+        err = "expirationd: options.tuples_per_iteration must be a number",
+        options = {tuples_per_iteration = {"table"}},
+    },
+    vinyl_assumed_space_len_factor_number = {
+        ok = true,
+        options = {vinyl_assumed_space_len_factor = 333},
+    },
+    vinyl_assumed_space_len_factor_invalid = {
+        ok = false,
+        err = "expirationd: options.vinyl_assumed_space_len_factor must be a number",
+        options = {vinyl_assumed_space_len_factor = false},
+    },
+    vinyl_assumed_space_len_number = {
+        ok = true,
+        options = {vinyl_assumed_space_len = 1},
+    },
+    vinyl_assumed_space_len_invalid = {
+        ok = false,
+        err = "expirationd: options.vinyl_assumed_space_len must be a number",
+        options = {vinyl_assumed_space_len = "string"},
+    },
+}
+
+for k, case in pairs(options_cases) do
+    g["test_validate_config_option_" .. k] = function(cg)
+        local cfg = create_valid_required({options = case.options})
+        local status, res = pcall(cg.role.validate_config, cfg)
+        if case.ok then
+            t.assert_equals(status, true)
+            t.assert_equals(res, true)
+        else
+            t.assert_equals(status, false)
+            t.assert_str_contains(res, case.err)
+        end
+    end
+end
+
+function g.test_apply_config_start_tasks(cg)
+    local task_name1 = "apply_config_test1"
+    local task_name2 = "apply_config_test2"
+
+    cg.role.apply_config({
+        expirationd = {
+            [task_name1] = {
+                space_id = g.space.id,
+                is_expired = always_true_func_name,
+            },
+            [task_name2] = {
+                space_id = g.space.id,
+                is_expired = always_true_func_name,
+                options = {}
+            },
+        }
+    }, {is_master = false})
+
+    t.assert_equals(#cg.role.tasks(), 2)
+    t.assert_not_equals(cg.role.task(task_name1), nil)
+    t.assert_not_equals(cg.role.task(task_name2), nil)
+end
+
+function g.test_apply_config_start_task_with_all_options(cg)
+    local task_name = "apply_config_test"
+    local options =  {
+        args = {"any"},
+        atomic_iteration = false,
+        force = false,
+        force_allow_functional_index = true,
+        full_scan_delay = 1,
+        full_scan_time = 1,
+        index = 0,
+        iterate_with = iterate_pairs_func_name,
+        iteration_delay = 1,
+        iterator_type = "ALL",
+        on_full_scan_complete = always_true_func_name,
+        on_full_scan_error = always_true_func_name,
+        on_full_scan_start = always_true_func_name,
+        on_full_scan_success = always_true_func_name,
+        process_expired_tuple = always_true_func_name,
+        process_while = always_true_func_name,
+        start_key = {1},
+        tuples_per_iteration = 100,
+        vinyl_assumed_space_len_factor = 1,
+        vinyl_assumed_space_len = 100,
+    }
+
+    cg.role.apply_config({
+        expirationd = {
+            [task_name] = {
+                space_id = g.space.id,
+                is_expired = always_true_func_name,
+                options = options,
+            }
+        },
+    }, {is_master = true})
+
+    t.assert_equals(#cg.role.tasks(), 1)
+    t.assert_not_equals(cg.role.task(task_name), nil)
+
+    -- pass an invalid option
+    options.full_scan_time = -100
+    local ok, _ = pcall(cg.role.apply_config, {
+        expirationd = {
+            [task_name] = {
+                space_id = g.space.id,
+                is_expired = always_true_func_name,
+                options = options,
+            }
+        },
+    }, {is_master = true})
+    t.assert_equals(ok, false)
+    t.assert_equals(#cg.role.tasks(), 0)
+end
+
+function g.test_apply_config_skip_is_master_only(cg)
+    local task_name = "apply_config_test"
+
+    cg.role.apply_config({
+        expirationd = {
+            [task_name] = {
+                space_id = g.space.id,
+                is_expired = always_true_func_name,
+                is_master_only = true,
+            },
+        },
+    }, {is_master = false})
+
+    t.assert_equals(#cg.role.tasks(), 0)
+end
+
+function g.test_apply_config_start_is_master_only(cg)
+    local task_name = "apply_config_test"
+
+    cg.role.apply_config({
+        expirationd = {
+            [task_name] = {
+                space_id = g.space.id,
+                is_expired = always_true_func_name,
+                is_master_only = true,
+            },
+        },
+    }, {is_master = true})
+
+    t.assert_equals(#cg.role.tasks(), 1)
+    t.assert_not_equals(cg.role.task(task_name), nil)
+end
+
+function g.test_apply_config_empty_repeat_kill_all_config_tasks(cg)
+    local local_name1 = "local_task1"
+    local local_name2 = "local_task2"
+    local config_name1 = "config_task1"
+    local config_name2 = "config_task2"
+    local config_name3 = "config_task3"
+
+    expirationd.start(local_name1, cg.space.id, function() return true end)
+    expirationd.start(local_name2, cg.space.id, function() return true end)
+
+    cg.role.apply_config({
+        expirationd = {
+            [config_name1] = {
+                space_id = g.space.id,
+                is_expired = always_true_func_name,
+            },
+            [config_name2] = {
+                space_id = g.space.id,
+                is_expired = always_true_func_name,
+            },
+            [config_name3] = {
+                space_id = g.space.id,
+                is_expired = always_true_func_name,
+            },
+        },
+    }, {is_master = false})
+
+    t.assert_equals(#cg.role.tasks(), 5)
+    t.assert_not_equals(cg.role.task(local_name1), nil)
+    t.assert_not_equals(cg.role.task(local_name2), nil)
+    t.assert_not_equals(cg.role.task(config_name1), nil)
+    t.assert_not_equals(cg.role.task(config_name2), nil)
+    t.assert_not_equals(cg.role.task(config_name3), nil)
+
+    cg.role.apply_config({}, {is_master = false})
+
+    t.assert_equals(#cg.role.tasks(), 2)
+    t.assert_not_equals(cg.role.task(local_name1), nil)
+    t.assert_not_equals(cg.role.task(local_name2), nil)
+end
+
+function g.test_apply_config_empty_repeat_handle_custom_stops(cg)
+    local config_name1 = "config_task1"
+    local config_name2 = "config_task2"
+    local config_name3 = "config_task3"
+
+    cg.role.apply_config({
+        expirationd = {
+            [config_name1] = {
+                space_id = g.space.id,
+                is_expired = always_true_func_name,
+            },
+            [config_name2] = {
+                space_id = g.space.id,
+                is_expired = always_true_func_name,
+            },
+            [config_name3] = {
+                space_id = g.space.id,
+                is_expired = always_true_func_name,
+            },
+        },
+    }, {is_master = false})
+
+    t.assert_equals(#cg.role.tasks(), 3)
+    t.assert_not_equals(cg.role.task(config_name1), nil)
+    t.assert_not_equals(cg.role.task(config_name2), nil)
+    t.assert_not_equals(cg.role.task(config_name3), nil)
+
+    cg.role.task(config_name1):stop()
+    cg.role.task(config_name2):kill()
+    cg.role.apply_config({}, {is_master = false})
+
+    t.assert_equals(#cg.role.tasks(), 0)
+end
+
+function g.test_apply_config_repeat_kill_old_config_tasks(cg)
+    local local_name1 = "local_task1"
+    local local_name2 = "local_task2"
+    local config_name1 = "config_task1"
+    local config_name2 = "config_task2"
+    local config_name3 = "config_task3"
+
+    expirationd.start(local_name1, cg.space.id, function() return true end)
+    expirationd.start(local_name2, cg.space.id, function() return true end)
+
+    cg.role.apply_config({
+        expirationd = {
+            [config_name1] = {
+                space_id = g.space.id,
+                is_expired = always_true_func_name,
+            },
+            [config_name2] = {
+                space_id = g.space.id,
+                is_expired = always_true_func_name,
+            },
+            [config_name3] = {
+                space_id = g.space.id,
+                is_expired = always_true_func_name,
+            },
+        },
+    }, {is_master = false})
+
+    t.assert_equals(#cg.role.tasks(), 5)
+    t.assert_not_equals(cg.role.task(local_name1), nil)
+    t.assert_not_equals(cg.role.task(local_name2), nil)
+    t.assert_not_equals(cg.role.task(config_name1), nil)
+    t.assert_not_equals(cg.role.task(config_name2), nil)
+    t.assert_not_equals(cg.role.task(config_name3), nil)
+
+    cg.role.apply_config({
+        expirationd = {
+            [config_name2] = {
+                space_id = cg.space.id,
+                is_expired = always_true_func_name,
+            },
+        },
+    }, {is_master = false})
+
+    t.assert_equals(#cg.role.tasks(), 3)
+    t.assert_not_equals(cg.role.task(local_name1), nil)
+    t.assert_not_equals(cg.role.task(local_name2), nil)
+    t.assert_not_equals(cg.role.task(config_name2), nil)
+end


### PR DESCRIPTION
`cartridge.roles.expirationd` is a Tarantool Cartridge role for the expirationd
package with the features:

* It registers expirationd as a Tarantool Cartridge service for easy access to
  all [API calls](https://tarantool.github.io/expirationd/#Module_functions):
  ```Lua
  local task = cartridge.service_get('expirationd').start("task_name", id, is_expired)
  task:kill()
  ```
* The role stops all expirationd tasks on an instance on the role termination.
* The role can automatically start or kill old tasks from the role
  configuration:

  ```yaml
  expirationd:
    task_name1:
      space_id: 579
      is_expired: is_expired_func_name_in__G
      is_master_only: true
      options:
        args:
        - any
        atomic_iteration: false
        force: false
        force_allow_functional_index: true
        full_scan_delay: 1
        full_scan_time: 1
        index: 0
        iterate_with: iterate_with_func_name_in__G
        iteration_delay: 1
        iterator_type: ALL
        on_full_scan_complete: on_full_scan_complete_func_name_in__G
        on_full_scan_error: on_full_scan_error_func_name_in__G
        on_full_scan_start: on_full_scan_start_func_name_in__G
        on_full_scan_success: on_full_scan_success_func_name_in__G
        process_expired_tuple: process_expired_tuple_func_name_in__G
        process_while: process_while_func_name_in__G
        start_key:
        - 1
        tuples_per_iteration: 100
        vinyl_assumed_space_len: 100
        vinyl_assumed_space_len_factor: 1
    task_name2:
      ...
  ```

  [expirationd.start()](https://tarantool.github.io/expirationd/#start) has
  the same parameters with the same meaning. Except for the additional optional
  param `is_master_only`. It defines is a task should be started only on a
  master instance. It is `false` by default.

  Also you need to be careful with the parameters-functions. The string is
  a key of in the global variable `_G` and the value must be a function. So
  something like this should be done before initializing the role:
  ```Lua
  rawset(_G, "is_expired_func_name_in__G", function(args, tuple)
      --logic
  end)
  ```

Closes #107