### PR TITLE
cd: add package deploy workflow

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -1,0 +1,91 @@
+name: packaging
+
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'master'
+    tags:
+      - '*'
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - { os: 'debian', dist: 'stretch' }
+          - { os: 'debian', dist: 'buster' }
+          - { os: 'debian', dist: 'bullseye' }
+          - { os: 'el', dist: '7' }
+          - { os: 'el', dist: '8' }
+          - { os: 'fedora', dist: '30' }
+          - { os: 'fedora', dist: '31' }
+          - { os: 'fedora', dist: '32' }
+          - { os: 'fedora', dist: '33' }
+          - { os: 'fedora', dist: '34' }
+          - { os: 'fedora', dist: '35' }
+          - { os: 'fedora', dist: '36' }
+          - { os: 'ubuntu', dist: 'xenial' }
+          - { os: 'ubuntu', dist: 'bionic' }
+          - { os: 'ubuntu', dist: 'focal' }
+          - { os: 'ubuntu', dist: 'groovy' }
+          - { os: 'ubuntu', dist: 'jammy' }
+
+    env:
+      OS: ${{ matrix.platform.os }}
+      DIST: ${{ matrix.platform.dist }}
+
+    steps:
+      - name: Clone the module
+        uses: actions/checkout@v3
+        # `actions/checkout` performs shallow clone of repo. To provide
+        # proper version of the package to `packpack` we need to have
+        # complete repository, otherwise it will be `0.0.1`.
+        with:
+          fetch-depth: 0
+
+      - name: Clone the packpack tool
+        uses: actions/checkout@v3
+        with:
+          repository: packpack/packpack
+          path: packpack
+
+      - name: Fetch tags
+        # Found that Github checkout Actions pulls all the tags, but
+        # right it deannotates the testing tag, check:
+        #   https://github.com/actions/checkout/issues/290
+        # But we use 'git describe ..' calls w/o '--tags' flag and it
+        # prevents us from getting the needed tag for packages version
+        # setup. To avoid of it, let's fetch it manually, to be sure
+        # that all tags will exist always.
+        run: git fetch --tags -f
+
+      - name: Create packages
+        run: ./packpack/packpack
+
+      - name: Deploy packages
+        # We need this step to run only on push with tag.
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
+        env:
+          RWS_URL_PART: https://rws.tarantool.org/tarantool-modules
+          RWS_AUTH: ${{ secrets.RWS_AUTH }}
+          PRODUCT_NAME: tarantool-expirationd
+        working-directory: build
+        run: |
+          CURL_CMD="curl -LfsS \
+            -X PUT ${RWS_URL_PART}/${OS}/${DIST} \
+            -u ${RWS_AUTH} \
+            -F product=${PRODUCT_NAME}"
+
+          shopt -s nullglob
+          for f in *.deb *.rpm *.dsc *.tar.xz *.tar.gz; do
+            CURL_CMD+=" -F $(basename ${f})=@${f}"
+          done
+
+          echo ${CURL_CMD}
+
+          ${CURL_CMD}

--- a/debian/control
+++ b/debian/control
@@ -13,7 +13,7 @@ Vcs-Browser: https://github.com/tarantool/expirationd
 
 Package: tarantool-expirationd
 Architecture: all
-Depends: tarantool (>= 1.6.8.0), ${misc:Depends}
+Depends: tarantool (>= 1.6.8.0), tarantool-checks (>= 2.1), ${misc:Depends}
 Description: Expiration daemon for Tarantool
  This package can turn Tarantool into a persistent memcache replacement,
  but is powerful enough so that your own expiration strategy can be defined.

--- a/debian/prebuild.sh
+++ b/debian/prebuild.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail
+
+curl -LsSf https://www.tarantool.io/release/1.10/installer.sh | sudo bash

--- a/debian/rules
+++ b/debian/rules
@@ -2,3 +2,9 @@
 
 %:
 	dh $@
+
+override_dh_auto_build:
+
+
+override_dh_auto_test:
+	DEB_BUILD_OPTIONS=nocheck dh_auto_test

--- a/expirationd-scm-1.rockspec
+++ b/expirationd-scm-1.rockspec
@@ -12,7 +12,7 @@ description = {
 }
 dependencies = {
     "lua >= 5.1", -- actually tarantool > 1.6
-    "checks == 3.1.0-1",
+    "checks >= 2.1",
 }
 build = {
     type = "builtin",

--- a/rpm/prebuild.sh
+++ b/rpm/prebuild.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -exu  # Strict shell (w/o -o pipefail)
+
+curl -LsSf https://www.tarantool.io/release/1.10/installer.sh | sudo bash

--- a/rpm/tarantool-expirationd.spec
+++ b/rpm/tarantool-expirationd.spec
@@ -24,9 +24,6 @@ some other space.
 %prep
 %setup -q -n %{name}-%{version}
 
-%check
-make test
-
 %install
 install -d %{buildroot}%{_datarootdir}/tarantool/
 install -m 0644 expirationd.lua %{buildroot}%{_datarootdir}/tarantool/

--- a/rpm/tarantool-expirationd.spec
+++ b/rpm/tarantool-expirationd.spec
@@ -10,6 +10,7 @@ BuildArch: noarch
 BuildRequires: tarantool >= 1.6.8.0
 BuildRequires: /usr/bin/prove
 Requires: tarantool >= 1.6.8.0
+Requires: tarantool-checks >= 2.1
 %description
 This package can turn Tarantool into a persistent memcache replacement,
 but is powerful enough so that your own expiration strategy can be defined.


### PR DESCRIPTION
This workflow is intended to run on a tag push for creating and deploying module packages to S3 based repositories.

We don't have the tarantool-luatest package in any public repository for all supported distros. We have to skip the test step until the tarantool-luatest is built at least for S3 repository.

It also fixed tarantool-checks dependency for deb/rpm packages, decreases required tarantool-checks from 3.1 to 2.1.

See other similar pull requests:

https://github.com/tarantool/queue/pull/157 , https://github.com/tarantool/http/pull/164

Closes #43 
Closes #124 