### PR TITLE
Release 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,40 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+## 1.3.0 - 2022-08-11
+
+This release adds a Tarantool Cartridge role for expirationd package and
+improves the default behavior.
+
+### Added
+
+- Continue a task from a last tuple (#54).
+- Process a task on a writable space by default (#42).
+- Wait until a space or an index is created (#68, #116).
+- Tarantool Cartridge role (#107).
+- Shuffle tests (#118).
+- GitHub Actions workflow with debug Tarantool build (#102).
+- GitHub Actions workflow for deploying module packages to S3 based
+  repositories (#43).
+
+### Changed
+
+- Decrease tarantool-checks dependency from 3.1 to 2.1 (#124).
+- expirationd.start() parameter `space_id` has been renamed to `space` (#112).
+
+### Deprecated
+
+- Obsolete functions: task_stats, kill_task, get_task, get_tasks, run_task,
+  show_task_list.
+
+### Fixed
+
+- Do not restart a work fiber if an index does not exist (#64).
+- Build and installation of rpm/deb packages (#124).
+- test_mvcc_vinyl_tx_conflict (#104, #105).
+- Flaky 'simple expires test' (#90).
+- Changelogs.
+
 ## 1.2.0 - 2022-06-27
 
 This release adds a lot of test fixes, documentation and CI improvements. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,119 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Fixed
+
+## 1.2.0 - 2022-06-27
+
+This release adds a lot of test fixes, documentation and CI improvements. The
+main new feature is support of metrics package. Collecting statistics using the
+metrics package is enabled by default if the package metrics >= 0.11.0
+is installed.
+
+4 counters will be created:
+
+1. expirationd_checked_count
+2. expirationd_expired_count
+3. expirationd_restarts
+4. expirationd_working_time
+
+The meaning of counters is same as for expirationd.stats().
+
+It can be disabled using the expirationd.cfg call:
+
+```Lua
+expirationd.cfg({metrics = false})
+```
+
+### Added
+
+- Check types of function arguments with checks module (#58).
+- Messages about obsolete methods.
+- Metrics support (#100).
+- Tests use new version of API.
+- Tests for expirationd.stats() (#77).
+- Gather code coverage and send report to coveralls on GitHub CI (#85).
+- Print engine passed to tests (#76).
+- Support to generate documentation using make (#79).
+- Note about using expirationd with replication (#14).
+- New target deps to Makefile that install lua dependencies (#79).
+- GitHub CI for publishing API documentation (#79).
+- Describe prerequisites and installation steps in README.md.
+
+### Changed
+
+- Update documentation and convert to LDoc format (#60).
+- Update comparison table in README.md (#53).
+- Bump luatest version to 0.5.6.
+
+### Fixed
+
+- Prevent iteration through a functional index for Tarantool < 2.8.4 (#101).
+- Processing tasks with zero length box.cfg.replication (#95).
+- Remove check for vinyl engine (#76).
+- Flakiness (#76, #90, #80).
+- Make iterate_with() conform to declared interface (#84).
+- Use default 'vinyl_memory' quota for tests (#104).
+- A typo in the rpm-package description.
+- Function name in example:
+  function on_full_scan_complete -> function on_full_scan_error.
+- Incorrect description of the force option for the expirationd.start (#92,
+  #96).
+
+## 1.1.1 - 2021-09-13
+
+This release adds a fix for a bug with freezing on stop a task.
+
+### Added
+
+- Enable Lua source code analysis with luacheck (#57).
+
+### Fixed
+
+- Freezes when stopping a task (#69).
+
+## 1.1.0 - 2021-07-06
+
+This release adds a number of features and fixes a bug.
+
+### Added
+
+- The ability to set iteration and full scan delays for a task (#38).
+- Callbacks for a task at various stages of the full scan iteration (#25).
+- The ability to specify from where to start the iterator (option start_key)
+  and specify the type of the iterator itself (option iterator_type).
+  Start key can be set as a function (dynamic parameter) or just a static
+  value. The type of the iterator can be specified either with the
+  `box.index.*` constant, or with the name for example, 'EQ' or
+  box.index.EQ (#50).
+- The ability to create a custom iterator that will be created at the selected
+  index (option iterate_with). One can also pass a predicate that will stop the
+  full-scan process, if required (process_while) (#50).
+- An option atomic_iteration that allows making only one transaction per batch
+  option. With task:kill(), the batch with transactions will be finalized, and
+  only after that, the fiber will complete its work (#50).
+
+### Fixed
+
+- Worker iteration for a tree index. The bug can cause an array of tuples for a
+  check on expiration to be obtained before suspending during the worker
+  iteration (in case of using a tree index), and some tuples can be
+  modified/deleted from another fiber while the worker fiber is sleeping.
+
+## 1.0.1 - 2018-01-22
+
+First release with rockspecs.
+
+### Added
+
+- rockspecs.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,51 @@
+tarantool-expirationd (1.2.0-1) unstable; urgency=medium
+
+  * Check types of function arguments with checks module
+  * Add messages about obsolete methods
+  * Add metrics support
+  * Prevent iteration through a functional index for Tarantool < 2.8.4
+  * Fix processing tasks with zero length box.cfg.replication
+  * Make iterate_with() conform to declared interface
+  * Update documentation and convert to LDoc format
+  * Support to generate documentation using make
+  * Update comparison table in README.md
+  * Add note about using expirationd with replication
+  * Fix function name in example:
+    function on_full_scan_complete -> function on_full_scan_error
+  * Describe prerequisites and installation steps in README.md
+  * Bump luatest version to 0.5.6
+  * Fix incorrect description of the force option for the expirationd.start
+
+ -- Oleg Jukovec <oleg.jukovec@tarantool.org>  Mon, 27 Jun 2022 12:00:00 +0300
+
+tarantool-expirationd (1.1.1-1) unstable; urgency=medium
+
+  * Fix freezes when stopping a task
+  * Enable Lua source code analysis with luacheck
+
+ -- Sergey Bronnikov <sergeyb@tarantool.org>  Mon, 13 Sep 2021 12:00:00 +0300
+
+tarantool-expirationd (1.1.0-1) unstable; urgency=medium
+
+  * Add the ability to set iteration and full scan delays for a task.
+  * Add callbacks for a task at various stages of the full scan iteration.
+  * Add the ability to specify from where to start the iterator
+    (option start_key) and specify the type of the iterator itself
+    (option iterator_type)
+  * Add the ability to create a custom iterator that will be created at the
+    selected index (option iterate_with)
+  * Add an option atomic_iteration that allows making only one transaction per
+    batch option
+  * Fix worker iteration for a tree index
+
+ -- Sergey Bronnikov <sergeyb@tarantool.org>  Tue, 06 Jul 2021 12:00:00 +0300
+
+tarantool-expirationd (1.0.1-1) unstable; urgency=medium
+
+  * First release with rockspecs
+
+ -- Roman Tsisyk <roman@tarantool.org>  Sat, 22 Jan 2018 12:00:00 +0300
+
 tarantool-expirationd (1.0.0-1) unstable; urgency=medium
 
   * Initial release

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,16 @@
+tarantool-expirationd (1.3.0-1) unstable; urgency=medium
+
+  * Continue a task from a last tuple
+  * Decrease tarantool-checks dependency from 3.1 to 2.1
+  * Process a task on a writable space by default
+  * Wait until a space or an index is created
+  * Tarantool Cartridge role
+  * Fix build and installation of rpm/deb packages
+  * Do not restart a work fiber if an index does not exist
+  * expirationd.start() parameter space_id has been renamed to space
+
+ -- Oleg Jukovec <oleg.jukovec@tarantool.org>  Thu, 11 Aug 2022 12:00:00 +0300
+
 tarantool-expirationd (1.2.0-1) unstable; urgency=medium
 
   * Check types of function arguments with checks module

--- a/rpm/tarantool-expirationd.spec
+++ b/rpm/tarantool-expirationd.spec
@@ -38,5 +38,42 @@ install -m 0644 cartridge/roles/expirationd.lua %{buildroot}%{_datarootdir}/tara
 %license LICENSE
 
 %changelog
+* Mon Jun 27 2022 Oleg Jukovec <oleg.jukovec@tarantool.org> 1.2.0-1
+- Check types of function arguments with checks module
+- Add messages about obsolete methods
+- Add metrics support
+- Prevent iteration through a functional index for Tarantool < 2.8.4
+- Fix processing tasks with zero length box.cfg.replication
+- Make iterate_with() conform to declared interface
+- Update documentation and convert to LDoc format
+- Support to generate documentation using make
+- Update comparison table in README.md
+- Add note about using expirationd with replication
+- Fix a typo in the rpm-package description
+- Fix function name in example:
+  function on_full_scan_complete -> function on_full_scan_error
+- Describe prerequisites and installation steps in README.md
+- Bump luatest version to 0.5.6
+- Fix incorrect description of the force option for the expirationd.start
+
+* Mon Sep 13 2021 Sergey Bronnikov <sergeyb@tarantool.org> 1.1.1-1
+- Fix freezes when stopping a task
+- Enable Lua source code analysis with luacheck
+
+* Tue Jul 06 2021 Sergey Bronnikov <sergeyb@tarantool.org> 1.1.0-1
+- Add the ability to set iteration and full scan delays for a task.
+- Add callbacks for a task at various stages of the full scan iteration.
+- Add the ability to specify from where to start the iterator
+  (option start_key) and specify the type of the iterator itself
+  (option iterator_type)
+- Add the ability to create a custom iterator that will be created at the
+  selected index (option iterate_with)
+- Add an option atomic_iteration that allows making only one transaction per
+  batch option
+- Fix worker iteration for a tree index
+
+* Sat Jan 22 2018 Roman Tsisyk <roman@tarantool.org> 1.0.1-1
+- First release with rockspecs
+
 * Thu Jun 18 2015 Roman Tsisyk <roman@tarantool.org> 1.0.0-1
 - Initial version of the RPM spec

--- a/rpm/tarantool-expirationd.spec
+++ b/rpm/tarantool-expirationd.spec
@@ -38,6 +38,16 @@ install -m 0644 cartridge/roles/expirationd.lua %{buildroot}%{_datarootdir}/tara
 %license LICENSE
 
 %changelog
+* Thu Aug 11 2022 Oleg Jukovec <oleg.jukovec@tarantool.org> 1.3.0-1
+- Continue a task from a last tuple
+- Decrease tarantool-checks dependency from 3.1 to 2.1
+- Process a task on a writable space by default
+- Wait until a space or an index is created
+- Tarantool Cartridge role
+- Fix build and installation of rpm/deb packages
+- Do not restart work a fiber if an index does not exist
+- expirationd.start() parameter space_id has been renamed to space
+
 * Mon Jun 27 2022 Oleg Jukovec <oleg.jukovec@tarantool.org> 1.2.0-1
 - Check types of function arguments with checks module
 - Add messages about obsolete methods


### PR DESCRIPTION
## Overview

This release adds a Tarantool Cartridge role for expirationd package and improves the default behavior.

## Breaking changes

None.

## Deprecated

* Obsolete functions: task_stats, kill_task, get_task, get_tasks, run_task, show_task_list.

## New features

* Continue a task from a last tuple (#54).
* Decrease tarantool-checks dependency from 3.1 to 2.1 (#124).
* Process a task on a writable space by default (#42).
* Wait until a space or an index is created (#68, #116).
* Tarantool Cartridge role (#107).

## Bugfixes

* Fix build and installation of rpm/deb packages (#124).
* Do not restart a work fiber if an index does not exist (#64). 
* Update changelogs.

## Testing

* Shuffle tests (#118).
* Fix test_mvcc_vinyl_tx_conflict (#104, #105).
* Fix flaky 'simple expires test' (#90).

## Other

* expirationd.start() parameter `space_id` has been renamed to `space` (#112).
* Add GitHub Actions workflow with debug Tarantool build (#102).
* Add GitHub Actions workflow for deploying module packages to S3 based repositories (#43).

Draft release: https://github.com/tarantool/expirationd/releases/tag/untagged-2739e664e139341b1c84