### PR TITLE
api: rename space_id parameter to space

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ function is_expired(args, tuple)
   return true
 end
 
-function delete_tuple(space_id, args, tuple)
-  box.space[space_id]:delete{tuple[1]}
+function delete_tuple(space, args, tuple)
+  box.space[space]:delete{tuple[1]}
 end
 
 expirationd.start(job_name, space.id, is_expired, {
@@ -164,7 +164,7 @@ package with features:
   ```yaml
   expirationd:
     task_name1:
-      space_id: 579
+      space: 579
       is_expired: is_expired_func_name_in__G
       is_master_only: true
       options:

--- a/cartridge/roles/expirationd.lua
+++ b/cartridge/roles/expirationd.lua
@@ -106,7 +106,7 @@ local function get_task_config(task_conf)
     -- setmetatable resets __newindex write protection on a copy
     local conf = setmetatable(table.deepcopy(task_conf), {})
     local params_map = {
-        space_id = {required = true, types = {"n", "s"}},
+        space = {required = true, types = {"n", "s"}},
         is_expired = {required = true, types = {"f"}},
         is_master_only = {required = false, types = {"b"}},
         options = {required = false, types = {"t"}},
@@ -181,7 +181,7 @@ local function apply_config(conf_new, opts)
 
         local skip = task_conf.is_master_only and not opts.is_master
         if not skip then
-            local task = expirationd.start(task_name, task_conf.space_id,
+            local task = expirationd.start(task_name, task_conf.space,
                                            task_conf.is_expired,
                                            task_conf.options)
             if task == nil then

--- a/test/integration/role_test.lua
+++ b/test/integration/role_test.lua
@@ -84,7 +84,7 @@ function g.test_start_task_from_config(cg)
     cg.cluster.main_server:upload_config({
         expirationd = {
             test_task = {
-                space_id = "customers",
+                space = "customers",
                 is_expired = "always_true_test",
                 is_master_only = true,
             }
@@ -122,7 +122,7 @@ function g.test_continue_after_hotreload(cg)
     cg.cluster.main_server:upload_config({
         expirationd = {
             test_task = {
-                space_id = "customers",
+                space = "customers",
                 is_expired = "is_expired_test_continue",
                 is_master_only = true,
                 options = {

--- a/test/unit/role_test.lua
+++ b/test/unit/role_test.lua
@@ -107,21 +107,21 @@ local required_test_cases = {
     all_ok_space_number = {
         ok = true,
         cfg = { ["task_name"] = {
-            space_id = 1,
+            space = 1,
             is_expired = always_true_func_name,
         }}
     },
     all_ok_space_string = {
         ok = true,
         cfg = { ["task_name"] = {
-            space_id = "space name",
+            space = "space name",
             is_expired = always_true_func_name,
         }}
     },
     all_ok_empty_opts = {
         ok = true,
         cfg = { ["task_name"] = {
-            space_id = 1,
+            space = 1,
             is_expired = always_true_func_name,
             options = {}
         }}
@@ -133,7 +133,7 @@ local required_test_cases = {
     },
     no_space = {
         ok = false,
-        err = "expirationd: space_id is required",
+        err = "expirationd: space is required",
         cfg = { ["task_name"] = {
             is_expired = always_true_func_name,
         }}
@@ -142,22 +142,22 @@ local required_test_cases = {
         ok = false,
         err = "expirationd: is_expired is required",
         cfg = { ["task_name"] = {
-            space_id = 1,
+            space = 1,
         }}
     },
     invalid_name = {
         ok = false,
         err = "expirationd: task name must be a string",
         cfg = { [3] = {
-            space_id = "space name",
+            space = "space name",
             is_expired = always_true_func_name,
         }}
     },
     invalid_space = {
         ok = false,
-        err = "expirationd: space_id must be a number or a string",
+        err = "expirationd: space must be a number or a string",
         cfg = { ["task_name"] = {
-            space_id = {},
+            space = {},
             is_expired = always_true_func_name,
         }}
     },
@@ -165,7 +165,7 @@ local required_test_cases = {
         ok = false,
         err = "expirationd: is_expired must be a function name in _G",
         cfg = { ["task_name"] = {
-            space_id = 1,
+            space = 1,
             is_expired = 0,
         }}
     },
@@ -173,7 +173,7 @@ local required_test_cases = {
         ok = false,
         err = "expirationd: is_expired must be a function name in _G",
         cfg = { ["task_name"] = {
-            space_id = 1,
+            space = 1,
             is_expired = "any invelid func name",
         }}
     },
@@ -194,7 +194,7 @@ end
 
 local function create_valid_required(args)
     local new_args = table.deepcopy(args)
-    new_args["space_id"] = 1
+    new_args["space"] = 1
     new_args["is_expired"] = always_true_func_name
     return {expirationd = {["task_name"] = new_args}}
 end
@@ -471,11 +471,11 @@ function g.test_apply_config_start_tasks(cg)
     cg.role.apply_config({
         expirationd = {
             [task_name1] = {
-                space_id = g.space.id,
+                space = g.space.id,
                 is_expired = always_true_func_name,
             },
             [task_name2] = {
-                space_id = g.space.id,
+                space = g.space.id,
                 is_expired = always_true_func_name,
                 options = {}
             },
@@ -515,7 +515,7 @@ function g.test_apply_config_start_task_with_all_options(cg)
     cg.role.apply_config({
         expirationd = {
             [task_name] = {
-                space_id = g.space.id,
+                space = g.space.id,
                 is_expired = always_true_func_name,
                 options = options,
             }
@@ -530,7 +530,7 @@ function g.test_apply_config_start_task_with_all_options(cg)
     local ok, _ = pcall(cg.role.apply_config, {
         expirationd = {
             [task_name] = {
-                space_id = g.space.id,
+                space = g.space.id,
                 is_expired = always_true_func_name,
                 options = options,
             }
@@ -546,7 +546,7 @@ function g.test_apply_config_skip_is_master_only(cg)
     cg.role.apply_config({
         expirationd = {
             [task_name] = {
-                space_id = g.space.id,
+                space = g.space.id,
                 is_expired = always_true_func_name,
                 is_master_only = true,
             },
@@ -562,7 +562,7 @@ function g.test_apply_config_start_is_master_only(cg)
     cg.role.apply_config({
         expirationd = {
             [task_name] = {
-                space_id = g.space.id,
+                space = g.space.id,
                 is_expired = always_true_func_name,
                 is_master_only = true,
             },
@@ -586,15 +586,15 @@ function g.test_apply_config_empty_repeat_kill_all_config_tasks(cg)
     cg.role.apply_config({
         expirationd = {
             [config_name1] = {
-                space_id = g.space.id,
+                space = g.space.id,
                 is_expired = always_true_func_name,
             },
             [config_name2] = {
-                space_id = g.space.id,
+                space = g.space.id,
                 is_expired = always_true_func_name,
             },
             [config_name3] = {
-                space_id = g.space.id,
+                space = g.space.id,
                 is_expired = always_true_func_name,
             },
         },
@@ -622,15 +622,15 @@ function g.test_apply_config_empty_repeat_handle_custom_stops(cg)
     cg.role.apply_config({
         expirationd = {
             [config_name1] = {
-                space_id = g.space.id,
+                space = g.space.id,
                 is_expired = always_true_func_name,
             },
             [config_name2] = {
-                space_id = g.space.id,
+                space = g.space.id,
                 is_expired = always_true_func_name,
             },
             [config_name3] = {
-                space_id = g.space.id,
+                space = g.space.id,
                 is_expired = always_true_func_name,
             },
         },
@@ -661,15 +661,15 @@ function g.test_apply_config_repeat_kill_old_config_tasks(cg)
     cg.role.apply_config({
         expirationd = {
             [config_name1] = {
-                space_id = g.space.id,
+                space = g.space.id,
                 is_expired = always_true_func_name,
             },
             [config_name2] = {
-                space_id = g.space.id,
+                space = g.space.id,
                 is_expired = always_true_func_name,
             },
             [config_name3] = {
-                space_id = g.space.id,
+                space = g.space.id,
                 is_expired = always_true_func_name,
             },
         },
@@ -685,7 +685,7 @@ function g.test_apply_config_repeat_kill_old_config_tasks(cg)
     cg.role.apply_config({
         expirationd = {
             [config_name2] = {
-                space_id = cg.space.id,
+                space = cg.space.id,
                 is_expired = always_true_func_name,
             },
         },


### PR DESCRIPTION
expirationd.start() has the parameter space_id. The parameter name is
confusing because the value can be a name of a space, not just id.

This change does not affect an old code:

* It changes the name of the parameter, not the key in the options
  table. It doesn't break the current code.
* An user should not use a task.space_id field directly [1]. We are
  free to rename it.

1. https://github.com/tarantool/expirationd/blob/b9bcbe0a1782ffc1225c33d1eab78ef4e60162f8/expirationd.lua#L420-L423

Closes #112

It is the time to make this correction (if we really want it) so that the name doesn't get into the Tarantool Cartridge role parameter:
https://github.com/tarantool/expirationd/blob/b9bcbe0a1782ffc1225c33d1eab78ef4e60162f8/README.md?plain=1#L167

After the 1.3.0 release, it will be more difficult to change the parameter name.