### PR TITLE
test: fix vinyl_is_broken() check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Incorrect check of the Tarantool version in the tests to determine a bug in
+  the vinyl engine that breaks the tests (#103).
+
 ## 1.3.0 - 2022-08-11
 
 This release adds a Tarantool Cartridge role for expirationd package and

--- a/expirationd.lua
+++ b/expirationd.lua
@@ -199,7 +199,6 @@ local function check_space_and_index(task)
     end
 
     if space.engine == "memtx" and index.func ~= nil then
-        local supported = false
         local version = rawget(_G, "_TARANTOOL"):split('-', 1)[1]
         local major_minor_patch = version:split('.', 2)
 
@@ -208,10 +207,9 @@ local function check_space_and_index(task)
         local patch = tonumber(major_minor_patch[3])
         -- https://github.com/tarantool/expirationd/issues/101
         -- fixed since 2.8.4 and 2.10
-        if (major > 2) or (major == 2 and minor == 8 and patch >= 4)
-          or (major == 2 and minor >= 10) then
-            supported = true
-        end
+        local supported = (major == 2 and minor == 8 and patch >= 4) or
+            (major == 2 and minor >= 10) or
+            (major >= 3)
         local force_allow = task.force_allow_functional_index or false
         if not supported and not force_allow then
             return false, "Functional indices are not supported for" ..

--- a/test/helper.lua
+++ b/test/helper.lua
@@ -258,25 +258,33 @@ function helpers.tarantool_version()
     return major, minor, patch
 end
 
-function helpers.vinyl_is_broken()
-    -- Blocked by https://github.com/tarantool/tarantool/issues/6448
+function helpers.vinyl_is_supported()
     local major, minor, patch = helpers.tarantool_version()
 
-    -- Since Tarantool 1.10.11.
-    local broken_v1_10 = major >= 1 and (minor > 10 or minor == 10 and patch >= 11)
-
-    -- Tarantool >= 2.1.0 and < 2.8.2.
-    local broken_v2 = (major >= 2 and major < 3) and (minor >= 1 and minor < 8 or minor == 8 and patch <= 2)
-
-    return broken_v1_10 or broken_v2
+    -- The issue: https://github.com/tarantool/tarantool/issues/6448
+    --
+    -- The problem was introduced in 1.10.2 and fixed in 1.10.12, 2.8.3 and
+    -- after a 2.10 release.
+    return (major == 1 and minor <= 9) or
+        (major == 1 and minor == 10 and patch <= 1) or
+        (major == 1 and minor == 10 and patch >= 12) or
+        (major == 1 and minor >= 11) or
+        (major == 2 and minor == 8 and patch >= 3) or
+        (major == 2 and minor >= 10) or
+        (major >= 3)
 end
 
-function helpers.memtx_func_index_is_broken()
+function helpers.memtx_func_index_is_supported()
     local major, minor, patch = helpers.tarantool_version()
-    if major > 2 or (major == 2 and minor == 8 and patch >= 4) or (major == 2 and minor >= 10) then
-        return false
-    end
-    return true
+
+    -- The issue: https://github.com/tarantool/tarantool/issues/6786
+    --
+    -- Functional indexes for memtx storage engine are introduced in 2.2.1 with
+    -- a bug. The 1.10 series does not support them at all. The problem was
+    -- fixed in 2.8.4 and after a 2.10 release.
+    return (major == 2 and minor == 8 and patch >= 4) or
+        (major == 2 and minor >= 10) or
+        (major >= 3)
 end
 
 return helpers

--- a/test/unit/custom_index_test.lua
+++ b/test/unit/custom_index_test.lua
@@ -10,8 +10,9 @@ local g = t.group('custom_index', {
 })
 
 g.before_each({index_type = 'TREE'}, function(cg)
-    t.skip_if(cg.params.engine == 'vinyl' and helpers.vinyl_is_broken(),
-        'Blocked by https://github.com/tarantool/tarantool/issues/6448')
+    t.skip_if(cg.params.engine == 'vinyl' and not helpers.vinyl_is_supported(),
+        'Blocked by https://github.com/tarantool/tarantool/issues/6448 on ' ..
+		'this Tarantool version')
     g.space = helpers.create_space_with_tree_index(cg.params.engine)
 end)
 
@@ -197,11 +198,15 @@ function g.test_tree_index_multikey(cg)
     task:kill()
 end
 
-function g.test_memtx_tree_functional_index_broken(cg)
-    t.skip_if(_TARANTOOL < "2" or not helpers.memtx_func_index_is_broken(),
-              "Unsupported Tarantool version")
-    t.skip_if(cg.params.index_type ~= 'TREE', 'Unsupported index type')
+function g.test_memtx_tree_functional_index_broken_error(cg)
     t.skip_if(cg.params.engine == 'vinyl', 'Unsupported engine')
+    t.skip_if(cg.params.index_type ~= 'TREE', 'Unsupported index type')
+    t.skip_if(cg.space.index["functional_index"] == nil,
+        "Functional indexes are not supported by Tarantool")
+    t.skip_if(helpers.memtx_func_index_is_supported(),
+        "No errors expected from https://github.com/tarantool/tarantool/issues/6786 " ..
+		"on this Tarantool version")
+
     local expected = "Functional indices are not supported for Tarantool < 2.8.4," ..
                      " see options.force_allow_functional_index"
 
@@ -219,10 +224,13 @@ function g.test_memtx_tree_functional_index_broken(cg)
 end
 
 function g.test_memtx_tree_functional_index_force_broken(cg)
-    t.skip_if(_TARANTOOL < "2" or not helpers.memtx_func_index_is_broken(),
-              "Unsupported Tarantool version")
-    t.skip_if(cg.params.index_type ~= 'TREE', 'Unsupported index type')
     t.skip_if(cg.params.engine == 'vinyl', 'Unsupported engine')
+    t.skip_if(cg.params.index_type ~= 'TREE', 'Unsupported index type')
+    t.skip_if(cg.space.index["functional_index"] == nil,
+        "Functional indexes are not supported by Tarantool")
+    t.skip_if(helpers.memtx_func_index_is_supported(),
+        "No errors expected from https://github.com/tarantool/tarantool/issues/6786 " ..
+		"on this Tarantool version")
 
     helpers.iteration_result = {}
 
@@ -252,11 +260,16 @@ function g.test_memtx_tree_functional_index_force_broken(cg)
     task:kill()
 end
 
+-- Vinyl is not supported yet:
+-- https://github.com/tarantool/tarantool/issues/4492
 function g.test_memtx_tree_functional_index(cg)
-    t.skip_if(_TARANTOOL < "2" or helpers.memtx_func_index_is_broken(),
-              "Unsupported Tarantool version")
-    t.skip_if(cg.params.index_type ~= 'TREE', 'Unsupported index type')
     t.skip_if(cg.params.engine == 'vinyl', 'Unsupported engine')
+    t.skip_if(cg.params.index_type ~= 'TREE', 'Unsupported index type')
+    t.skip_if(cg.space.index["functional_index"] == nil,
+        "Functional indexes are not supported by Tarantool")
+    t.skip_if(not helpers.memtx_func_index_is_supported(),
+        "Blocked by https://github.com/tarantool/tarantool/issues/6786 on " ..
+		"this Tarantool version")
 
     helpers.iteration_result = {}
 

--- a/test/unit/expirationd_stats_test.lua
+++ b/test/unit/expirationd_stats_test.lua
@@ -11,8 +11,9 @@ local g = t.group('expirationd_stats', {
 })
 
 g.before_each({index_type = 'TREE'}, function(cg)
-    t.skip_if(cg.params.engine == 'vinyl' and helpers.vinyl_is_broken(),
-        'Blocked by https://github.com/tarantool/tarantool/issues/6448')
+    t.skip_if(cg.params.engine == 'vinyl' and not helpers.vinyl_is_supported(),
+        'Blocked by https://github.com/tarantool/tarantool/issues/6448 on ' ..
+		'this Tarantool version')
     g.space = helpers.create_space_with_tree_index(cg.params.engine)
 end)
 

--- a/test/unit/iterator_type_test.lua
+++ b/test/unit/iterator_type_test.lua
@@ -11,8 +11,9 @@ local g = t.group('iterator_type', {
 })
 
 g.before_each({index_type = 'TREE'}, function(cg)
-    t.skip_if(cg.params.engine == 'vinyl' and helpers.vinyl_is_broken(),
-        'Blocked by https://github.com/tarantool/tarantool/issues/6448')
+    t.skip_if(cg.params.engine == 'vinyl' and not helpers.vinyl_is_supported(),
+        'Blocked by https://github.com/tarantool/tarantool/issues/6448 on ' ..
+		'this Tarantool version')
     g.space = helpers.create_space_with_tree_index(cg.params.engine)
 end)
 

--- a/test/unit/start_key_test.lua
+++ b/test/unit/start_key_test.lua
@@ -10,8 +10,9 @@ local g = t.group('start_key', {
 })
 
 g.before_each({index_type = 'TREE'}, function(cg)
-    t.skip_if(cg.params.engine == 'vinyl' and helpers.vinyl_is_broken(),
-        'Blocked by https://github.com/tarantool/tarantool/issues/6448')
+    t.skip_if(cg.params.engine == 'vinyl' and not helpers.vinyl_is_supported(),
+        'Blocked by https://github.com/tarantool/tarantool/issues/6448 on ' ..
+		'this Tarantool version')
     g.space = helpers.create_space_with_tree_index(cg.params.engine)
 end)
 


### PR DESCRIPTION
The function may return true for Tarantool 2.11. It is incorrect
because the bug was fixed in 2.10:

     ...
     1.10   1.10.11-5-g40d8f4df1
     ...
     2.8    2.8.2-12-g2663a9c6c
     2.10   2.10.0-beta1-51-g0428bbcef
     master 2.10.0-beta1-51-g0428bbcef

The patch fixes the problem and unifies a code that checks a support
of features.

Closes #103