### PR TITLE
Release 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Add versioning support (#136).
-
 ### Changed
 
 ### Fixed
+
+## 1.4.0 - 2023-03-16
+
+The release adds `_VERSION` constant for the module.
+
+### Added
+
+- Add versioning support (#136).
 
 ## 1.3.1 - 2023-01-17
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+tarantool-expirationd (1.4.0-1) unstable; urgency=medium
+
+  * Add _VERSION constant
+
+ -- Oleg Jukovec <oleg.jukovec@tarantool.org>  Thu, 16 Mar 2023 12:00:00 +0300
+
 tarantool-expirationd (1.3.1-1) unstable; urgency=medium
 
   * Fix check of the Tarantool version in tests to determine a bug in

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+tarantool-expirationd (1.3.1-1) unstable; urgency=medium
+
+  * Fix check of the Tarantool version in tests to determine a bug in
+    the vinyl engine
+  * Add a way to configure the module using Tarantool Cartridge role
+    configuration
+
+ -- Oleg Jukovec <oleg.jukovec@tarantool.org>  Fri, 17 Jan 2023 12:00:00 +0300
+
 tarantool-expirationd (1.3.0-1) unstable; urgency=medium
 
   * Continue a task from a last tuple

--- a/expirationd/version.lua
+++ b/expirationd/version.lua
@@ -1,4 +1,4 @@
 -- Сontains the module version.
 -- Requires manual update in case of release commit.
 
-return '1.3.1'
+return '1.4.0'

--- a/rpm/tarantool-expirationd.spec
+++ b/rpm/tarantool-expirationd.spec
@@ -40,6 +40,10 @@ install -m 0644 cartridge/roles/expirationd.lua %{buildroot}%{_datarootdir}/tara
 
 %changelog
 
+* Thu Mar 16 2023 Oleg Jukovec <oleg.jukovec@tarantool.org> 1.4.0-1
+
+- Add _VERSION constant.
+
 * Fri Jan 17 2023 Oleg Jukovec <oleg.jukovec@tarantool.org> 1.3.1-1
 - Fix check of the Tarantool version in tests to determine a bug in
   the vinyl engine

--- a/rpm/tarantool-expirationd.spec
+++ b/rpm/tarantool-expirationd.spec
@@ -39,15 +39,12 @@ install -m 0644 cartridge/roles/expirationd.lua %{buildroot}%{_datarootdir}/tara
 %license LICENSE
 
 %changelog
-* Thu Aug 11 2022 Oleg Jukovec <oleg.jukovec@tarantool.org> 1.3.0-1
-- Continue a task from a last tuple
-- Decrease tarantool-checks dependency from 3.1 to 2.1
-- Process a task on a writable space by default
-- Wait until a space or an index is created
-- Tarantool Cartridge role
-- Fix build and installation of rpm/deb packages
-- Do not restart work a fiber if an index does not exist
-- expirationd.start() parameter space_id has been renamed to space
+
+* Fri Jan 17 2023 Oleg Jukovec <oleg.jukovec@tarantool.org> 1.3.1-1
+- Fix check of the Tarantool version in tests to determine a bug in
+  the vinyl engine
+- Add a way to configure the module using Tarantool Cartridge role
+  configuration
 
 * Mon Jun 27 2022 Oleg Jukovec <oleg.jukovec@tarantool.org> 1.2.0-1
 - Check types of function arguments with checks module


### PR DESCRIPTION
## Overview

The release adds `_VERSION` constant for the module.

## Breaking changes

None.

## New features

* Add versioning support (https://github.com/tarantool/expirationd/pull/136).