### PR TITLE
test: archive_by_timestamp

### DIFF
--- a/test.lua
+++ b/test.lua
@@ -282,80 +282,18 @@ init_box()
 
 -- ========================================================================= --
 -- TAP TESTS:
--- 1. simple archive test.
--- 2. errors test,
--- 3. not expire test,
--- 4. kill zombie test
--- 5. multiple expires test
--- 6. default drop function test
--- 7. restart test
--- 8. complex key test
--- 9. delays and scan callbacks test
--- 10. error callback test
+-- 1. errors test,
+-- 2. not expire test,
+-- 3. kill zombie test
+-- 4. multiple expires test
+-- 5. default drop function test
+-- 6. restart test
+-- 7. complex key test
+-- 8. delays and scan callbacks test
+-- 9. error callback test
 -- ========================================================================= --
-test:plan(10)
 
-test:test('simple expires test',  function(test)
-    test:plan(4)
-    -- put test tuples
-    log.info("-------------- put ------------")
-    log.info("put to space " .. prefix_space_id(space_id))
-
-    -- puts:
-    -- 5 tuples with the current time as an expiration (should be deleted)
-    -- 5 tuples with the current time + 120s as an expiration
-    -- 2 tuples with an invalid time (should be deleted)
-    put_test_tuples(space_id, 10, 120)
-
-    -- print before
-    log.info("------------- print -----------")
-    log.info("before print space " .. prefix_space_id(space_id), "\n")
-    print_test_tuples(space_id)
-    log.info("before print archive space " .. prefix_space_id(archive_space_id), "\n")
-    print_test_tuples(archive_space_id)
-
-    log.info("-------------- run ------------")
-    expirationd.start(
-        "test",
-        space_id,
-        check_tuple_expire_by_timestamp,
-        {
-            process_expired_tuple = put_tuple_to_archive,
-            args = {
-                field_no = 3,
-                archive_space_id = archive_space_id
-            },
-        }
-    )
-    local start_time = fiber.time()
-
-    -- sure that "test" task will be executed
-    fiber.yield()
-
-    -- print after
-    log.info("------------- print -----------")
-    log.info("After print space " .. prefix_space_id(space_id), "\n")
-    print_test_tuples(space_id)
-    log.info("after print archive space " .. prefix_space_id(archive_space_id), "\n")
-    print_test_tuples(archive_space_id)
-
-    expirationd.tasks()
-
-    local task = expirationd.task("test")
-    test:is(task.start_time, start_time, 'checking start time')
-    test:is(task.name, "test", 'checking task name')
-    local restarts = 1
-    test:is(task.restarts, restarts, 'checking restart count')
-    local res = wait_cond(
-        function()
-            local task = expirationd.task("test")
-            local cnt = task.expired_tuples_count
-            return cnt == 7
-        end
-    )
-    test:is(res, true, 'Test task executed and moved to archive')
-    expirationd.kill("test")
-end)
+test:plan(9)
 
 test:test("execution error test", function (test)
     test:plan(2)

--- a/test/helper.lua
+++ b/test/helper.lua
@@ -5,7 +5,7 @@ local helpers = require("luatest.helpers")
 
 helpers.project_root = fio.dirname(debug.sourcedir())
 
-local function create_space(space_name, engine)
+function helpers.create_space(space_name, engine)
     local space_format = {
         {
             name = "id",
@@ -53,7 +53,7 @@ local function create_space(space_name, engine)
 end
 
 function helpers.create_space_with_tree_index(engine)
-    local space = create_space("tree", engine)
+    local space = helpers.create_space("tree", engine)
 
     space:create_index("primary", {
         type = "TREE",
@@ -135,7 +135,7 @@ function helpers.create_space_with_tree_index(engine)
 end
 
 function helpers.create_space_with_hash_index(engine)
-    local space = create_space("hash", engine)
+    local space = helpers.create_space("hash", engine)
     space:create_index("primary", {
         type = "HASH",
         parts = {
@@ -168,7 +168,7 @@ function helpers.create_space_with_hash_index(engine)
 end
 
 function helpers.create_space_with_bitset_index(engine)
-    local space = create_space("bitset", engine)
+    local space = helpers.create_space("bitset", engine)
     space:create_index("primary", {
         type = "TREE",
         parts = {

--- a/test/unit/expiration_process_test.lua
+++ b/test/unit/expiration_process_test.lua
@@ -1,0 +1,111 @@
+local expirationd = require('expirationd')
+local fiber = require('fiber')
+local t = require('luatest')
+
+local helpers = require('test.helper')
+
+local g = t.group('expiration_process', {
+    {index_type = 'TREE', engine = 'vinyl'},
+    {index_type = 'TREE', engine = 'memtx'},
+    {index_type = 'HASH', engine = 'memtx'},
+})
+
+g.before_each({index_type = 'TREE'}, function(cg)
+    t.skip_if(cg.params.engine == 'vinyl' and not helpers.vinyl_is_supported(),
+        'Blocked by https://github.com/tarantool/tarantool/issues/6448')
+    g.space = helpers.create_space_with_tree_index(cg.params.engine)
+end)
+
+g.before_each({index_type = 'HASH'}, function(cg)
+    g.space = helpers.create_space_with_hash_index(cg.params.engine)
+end)
+
+g.before_each(function(cg)
+    local space_archive = helpers.create_space('archived_tree', cg.params.engine)
+    space_archive:create_index('primary')
+    g.space_archive = space_archive
+
+    cg.task_name = 'test'
+end)
+
+g.after_each(function(g)
+    if g.task ~= nil then
+        g.task:kill()
+    end
+    g.space:drop()
+    g.space_archive:drop()
+end)
+
+-- Check tuple's expiration by timestamp.
+local function check_tuple_expire_by_timestamp(args, tuple)
+    local tuple_expire_time = tuple[args.field_no]
+
+    local current_time = fiber.time()
+    return current_time >= tuple_expire_time
+end
+
+-- Put expired tuple in archive.
+local function put_tuple_to_archive(space_id, args, tuple)
+    -- Delete expired tuple.
+    box.space[space_id]:delete({tuple.id})
+    local id, first_name = tuple.id, tuple.first_name
+    if args.archive_space_id ~= nil and id ~= nil and first_name ~= nil then
+        box.space[args.archive_space_id]:insert({id, first_name, fiber.time()})
+    end
+end
+
+-- Checking that we can use custom is_tuple_expired, process_expired_tuple,
+-- these basic functions are included in expiration_process.
+-- We also test the timestamp expiration check.
+function g.test_archive_by_timestamp(cg)
+    local space = cg.space
+    local space_archive = cg.space_archive
+    local task_name = cg.task_name
+
+    local total = 10
+    local todelete = 5
+    local time = fiber.time()
+    local deleted = {}
+    local nondeleted = {}
+    for i = 1, total do
+        local tuple
+        if i <= todelete then
+            -- This tuples should be deleted by the expirationd.
+            tuple = {i, tostring(i), time}
+            table.insert(deleted, tuple)
+        else
+            -- This tuples should still exist.
+            tuple = {i, tostring(i), time + 60}
+            table.insert(nondeleted, tuple)
+        end
+        space:insert(tuple)
+    end
+
+    cg.task = expirationd.start(task_name, space.id,
+        check_tuple_expire_by_timestamp,
+        {
+            process_expired_tuple = put_tuple_to_archive,
+            args = {
+                field_no = 3,
+                archive_space_id = space_archive.id
+            },
+        })
+    local task = cg.task
+    local start_time = fiber.time()
+
+    -- We sure that the task will be executed.
+    helpers.retrying({}, function()
+        t.assert_equals(space_archive:count(), #deleted)
+    end)
+
+    -- Check the validity of the task parameters.
+    t.assert_equals(task.name, 'test')
+    t.assert_equals(task.name, task_name)
+    t.assert_equals(task.start_time, start_time)
+    t.assert_equals(task.restarts, 1)
+
+    -- Check tuple processing.
+    t.assert_equals(space_archive:count(), #deleted)
+    t.assert_equals(task.expired_tuples_count, #deleted)
+    t.assert_items_include(space:select(nil, {limit = 1000}), nondeleted)
+end


### PR DESCRIPTION
Transferring the taptest to the luatest testing system with renaming the tests and using the existing spaces in helpers.

Check if we can use specific is_tuple_expired, process_expired_tuple, these basic functions are included in expiration_process. Function is_tuple_expired checks the timestamp in the time field of tuple, and if current time is greater then time field then true. Function process_expired_tuple instead of simple deletion, does the archiving by deleting the tuple from the expirated space and insert into a new space that we create in before_each.

Updated test's name:

- simple expires test -> test_archive_by_timestamp

Part of #61