### PR TITLE
test: pass broken function in parameters

### DIFF
--- a/test.lua
+++ b/test.lua
@@ -4,7 +4,6 @@ local clock = require('clock')
 local fun = require('fun')
 local log = require('log')
 local tap = require('tap')
-local yaml = require('yaml')
 local fiber = require('fiber')
 local strict = require('strict')
 local expirationd = require('expirationd')
@@ -120,15 +119,6 @@ local function put_tuple_to_archive(space_id, args, tuple)
     end
 end
 
-local nonexistentfunction = nil
-
-local function check_tuple_expire_by_timestamp_error(args, tuple)
-   nonexistentfunction()
-end
-
-local function put_tuple_to_archive_error(space_id, args, tuple)
-   nonexistentfunction()
-end
 -- ========================================================================= --
 -- Expiration module test functions
 -- ========================================================================= --
@@ -282,50 +272,17 @@ init_box()
 
 -- ========================================================================= --
 -- TAP TESTS:
--- 1. errors test,
--- 2. not expire test,
--- 3. kill zombie test
--- 4. multiple expires test
--- 5. default drop function test
--- 6. restart test
--- 7. complex key test
--- 8. delays and scan callbacks test
--- 9. error callback test
+-- 1. not expire test,
+-- 2. kill zombie test
+-- 3. multiple expires test
+-- 4. default drop function test
+-- 5. restart test
+-- 6. complex key test
+-- 7. delays and scan callbacks test
+-- 8. error callback test
 -- ========================================================================= --
 
-test:plan(9)
-
-test:test("execution error test", function (test)
-    test:plan(2)
-    expirationd.start(
-        "test",
-        space_id,
-        check_tuple_expire_by_timestamp_error,
-        {
-            process_expired_tuple = put_tuple_to_archive,
-            args = {
-                field_no = 3,
-                archive_space_id = archive_space_id,
-            },
-        }
-    )
-    test:is(expirationd.task("test").restarts, 1, 'checking restart count')
-
-    expirationd.start("test",
-        space_id,
-        check_tuple_expire_by_timestamp,
-        {
-            process_expired_tuple = put_tuple_to_archive_error,
-            args = {
-                field_no = 3,
-                archive_space_id = archive_space_id,
-            },
-        }
-    )
-    local task = expirationd.task("test")
-    test:is(task.restarts, 1, 'Error task executed')
-    expirationd.kill("test")
-end)
+test:plan(8)
 
 test:test("not expired task",  function(test)
     test:plan(2)

--- a/test/helper.lua
+++ b/test/helper.lua
@@ -287,4 +287,8 @@ function helpers.memtx_func_index_is_supported()
         (major >= 3)
 end
 
+function helpers.error_function()
+    error("error function call")
+end
+
 return helpers

--- a/test/unit/expiration_process_test.lua
+++ b/test/unit/expiration_process_test.lua
@@ -109,3 +109,65 @@ function g.test_archive_by_timestamp(cg)
     t.assert_equals(task.expired_tuples_count, #deleted)
     t.assert_items_include(space:select(nil, {limit = 1000}), nondeleted)
 end
+
+function g.test_broken_is_tuple_expired(cg)
+    local space = cg.space
+    local space_archive = cg.space_archive
+    local task_name = cg.task_name
+
+    local full_scan_counter = 0
+    cg.task = expirationd.start(
+        task_name,
+        space.id,
+        helpers.error_function,
+        {
+            process_expired_tuple = put_tuple_to_archive,
+            args = {
+                field_no = 3,
+                archive_space_id = space_archive.id,
+            },
+            on_full_scan_complete = function()
+                full_scan_counter = full_scan_counter + 1
+            end
+        }
+    )
+    local task = cg.task
+
+    t.assert_equals(task.restarts, 1)
+
+    -- Check that task is alive and running.
+    helpers.retrying({}, function()
+        t.assert_ge(full_scan_counter, 3)
+    end)
+end
+
+function g.test_broken_process_expired_tuple(cg)
+    local space = cg.space
+    local space_archive = cg.space_archive
+    local task_name = cg.task_name
+
+    local full_scan_counter = 0
+    cg.task = expirationd.start(
+        task_name,
+        space.id,
+        check_tuple_expire_by_timestamp,
+        {
+            process_expired_tuple = helpers.error_function,
+            args = {
+                field_no = 3,
+                archive_space_id = space_archive.id,
+            },
+            on_full_scan_complete = function()
+                full_scan_counter = full_scan_counter + 1
+            end
+        }
+    )
+    local task = cg.task
+
+    t.assert_equals(task.restarts, 1)
+
+    -- Check that task is alive and running.
+    helpers.retrying({}, function()
+        t.assert_ge(full_scan_counter, 3)
+    end)
+end


### PR DESCRIPTION
Transferring the taptest to the luatest testing system with renaming the tests and using the existing spaces in helpers.

Updated test's name:

- execution error test -> test_broken_is_tuple_expired -> test_broken_process_expired_tuple

Part of #61