### PR TITLE
test: tuples_per_iteration

### DIFF
--- a/test.lua
+++ b/test.lua
@@ -382,7 +382,7 @@ test:test("restart test", function(test)
         }
     )
 
-    local fiber_cnt = len(fiber.info())
+    local old_fiber_cnt = len(fiber.info())
     local old_expd = expirationd
 
     local chan = fiber.channel(1)
@@ -408,7 +408,9 @@ test:test("restart test", function(test)
     test:is(space:count{}, 0, 'all tuples are expired')
 
     task1:statistics()
-    test:is(fiber_cnt, len(fiber.info()), "check for absence of ghost fibers")
+    local fiber_cnt = len(fiber.info())
+    -- After update the fiber named "main" may disappear.
+    test:ok(fiber_cnt <= old_fiber_cnt and old_fiber_cnt <= fiber_cnt + 1, "check for absence of ghost fibers")
 
     expirationd.kill("test1")
     expirationd.kill("test2")

--- a/test/unit/expiration_process_test.lua
+++ b/test/unit/expiration_process_test.lua
@@ -241,3 +241,41 @@ function g.test_default_tuple_drop_function(cg)
         t.assert_equals(space:count{}, 0)
     end)
 end
+
+function g.test_tuples_per_iteration(cg)
+    local space = cg.space
+    local space_archive = cg.space_archive
+    local task_name = cg.task_name
+
+    local total = 10
+    local time = fiber.time()
+    for i = 1, total do
+        space:insert({i, tostring(i), time})
+    end
+    t.assert_equals(space:count{}, total)
+
+    cg.task = expirationd.start(task_name, space.id, check_tuple_expire_by_timestamp,
+        {
+            process_expired_tuple = put_tuple_to_archive,
+            args = {
+                field_no = 3,
+                archive_space_id = space_archive.id
+            },
+            iteration_delay = 1,
+            vinyl_assumed_space_len = 5, -- Iteration_delay will be 1 sec.
+            tuples_per_iteration = 5,
+        })
+    local task = cg.task
+
+    -- Test first expire part.
+    local worker_fiber = task.worker_fiber
+    helpers.retrying({}, function()
+        t.assert_equals(task.expired_tuples_count, total / 2)
+        t.assert_equals(worker_fiber:status(), 'suspended')
+    end)
+
+    -- Test second expire part.
+    helpers.retrying({}, function()
+        t.assert_equals(task.expired_tuples_count, total)
+    end)
+end

--- a/test/unit/expiration_process_test.lua
+++ b/test/unit/expiration_process_test.lua
@@ -28,12 +28,12 @@ g.before_each(function(cg)
     cg.task_name = 'test'
 end)
 
-g.after_each(function(g)
-    if g.task ~= nil then
-        g.task:kill()
+g.after_each(function(cg)
+    if cg.task ~= nil then
+        cg.task:kill()
     end
-    g.space:drop()
-    g.space_archive:drop()
+    cg.space:drop()
+    cg.space_archive:drop()
 end)
 
 -- Check tuple's expiration by timestamp.
@@ -183,7 +183,7 @@ function g.test_check_tuples_not_expired_by_timestamp(cg)
         space:insert({i, tostring(i), time + 2})
     end
 
-    cg.full_scan_counter = 0
+    local full_scan_counter = 0
     cg.task = expirationd.start(task_name, space.id, check_tuple_expire_by_timestamp,
         {
             process_expired_tuple = put_tuple_to_archive,
@@ -192,7 +192,7 @@ function g.test_check_tuples_not_expired_by_timestamp(cg)
                 archive_space_id = space_archive.id
             },
             on_full_scan_complete = function()
-                cg.full_scan_counter = cg.full_scan_counter + 1
+                full_scan_counter = full_scan_counter + 1
             end
         })
     local task = cg.task
@@ -201,7 +201,7 @@ function g.test_check_tuples_not_expired_by_timestamp(cg)
     -- Сheck that after the expiration starts,
     -- no tuples will be archived since the timestamp has an advantage of 2 seconds.
     helpers.retrying({}, function()
-        t.assert(cg.full_scan_counter > 0)
+        t.assert(full_scan_counter > 0)
         t.assert_equals(task.expired_tuples_count, 0)
         t.assert_equals(space_archive:count(), 0)
     end)


### PR DESCRIPTION
Transferring the taptest to the luatest testing system with renaming the
tests and using the existing spaces in helpers.

Check that the task will expirate as many tuples in one batch as we
specify in tuples_per_iteration and sleep between iterations.

Updated test's name:

- multiple expires test -> test_tuples_per_iteration

Part of https://github.com/tarantool/expirationd/issues/61