### PR TITLE
test: error_callback

### DIFF
--- a/test/helper.lua
+++ b/test/helper.lua
@@ -291,4 +291,10 @@ function helpers.error_function()
     error("error function call")
 end
 
+function helpers.get_error_function(error_msg)
+    return function()
+        error(error_msg)
+    end
+end
+
 return helpers

--- a/test/unit/expiration_process_test.lua
+++ b/test/unit/expiration_process_test.lua
@@ -224,7 +224,7 @@ function g.test_default_tuple_drop_function(cg)
         space:insert({i, tostring(i), time})
     end
     -- Tuples are in space.
-    t.assert_equals(space:count{}, total)
+    t.assert_equals(space:count(), total)
 
     cg.task = expirationd.start(task_name, space.id, check_tuple_expire_by_timestamp,
         {
@@ -238,7 +238,7 @@ function g.test_default_tuple_drop_function(cg)
     helpers.retrying({}, function()
         t.assert_equals(task.expired_tuples_count, total)
         t.assert_equals(space_archive:count(), 0)
-        t.assert_equals(space:count{}, 0)
+        t.assert_equals(space:count(), 0)
     end)
 end
 
@@ -252,7 +252,7 @@ function g.test_tuples_per_iteration(cg)
     for i = 1, total do
         space:insert({i, tostring(i), time})
     end
-    t.assert_equals(space:count{}, total)
+    t.assert_equals(space:count(), total)
 
     cg.task = expirationd.start(task_name, space.id, check_tuple_expire_by_timestamp,
         {


### PR DESCRIPTION
Transferring the taptest to the luatest testing system with renaming the tests and using the existing spaces in helpers.

Let's calculate whether callbacks are called correctly in case of an error.

Updated test's name:

- error callback test -> test_error_callback

Part of #61