### PR TITLE
test: delete complex key test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ luacov.report.out
 tags
 .rocks
 doc/apidoc/
+.idea
 *.swp

--- a/test.lua
+++ b/test.lua
@@ -274,9 +274,8 @@ init_box()
 -- TAP TESTS:
 -- 1. kill zombie test
 -- 2. restart test
--- 3. complex key test
 -- ========================================================================= --
-test:plan(3)
+test:plan(2)
 
 test:test("zombie task kill", function(test)
     test:plan(4)
@@ -414,36 +413,6 @@ test:test("restart test", function(test)
     expirationd.kill("test2")
     expirationd.kill("test3")
     expirationd.kill("test4")
-end)
-
-test:test("complex key test", function(test)
-    test:plan(2)
-    local tuples_count = 10
-    local space_name = 'complex_test'
-    local space = box.space[space_name]
-
-    for i = 1, tuples_count do
-        space:insert{i, i*i + 100, fiber.time() + 1}
-    end
-
-    expirationd.start(
-        "test",
-        space_name,
-        check_tuple_expire_by_timestamp,
-        {
-            args = {
-                field_no = 3,
-                archive_space_id = archive_space_id
-            },
-            tuples_per_iteration = 10,
-            full_scan_time = 1,
-        }
-    )
-
-    test:is(space:count{}, tuples_count, 'tuples are in space')
-    fiber.sleep(3.1)
-    test:is(space:count{}, 0, 'all tuples are expired with default function')
-    expirationd.kill("test")
 end)
 
 os.exit(test:check() and 0 or 1)


### PR DESCRIPTION
This test checks the expiration of the space by multipart index.
A test with the same functionality exists in [1].

1. Iterate over any index https://github.com/tarantool/expirationd/commit/4f44e1b88e12a2a0346684cbda226e365da6167b

Part of https://github.com/tarantool/expirationd/issues/61