### PR TITLE
cartridge: ability to use persistent functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Added ability to use persistent functions in `box.func` with cartridge. User can configure
+  the role with persistent functions as callback for task.
+
 ### Changed
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -169,6 +169,16 @@ package with features:
   only affects the current node and does not update values in the clusterwide
   configuration. The manual change will be overwritten by a next
   `apply_config` call.
+* You can use persistent functions (i.e. created by `box.schema.func.create`).
+  When configuring, role tries firstly get function from global namespace
+  (`_G`) and if function was not found then role tries search in `box.func` for
+  function with the same name.
+
+  Be careful! At the moment of validating and applying config of expirationd
+  role all persistent functions must be created before, so to configure
+  cartridge application correctly you must do it in two steps: at the first
+  step you have to confgure migrations with creating persistent functions and
+  run them, at the second one put expirationd config.
 * The role stops all expirationd tasks on an instance on the role termination.
 * The role can automatically start or kill old tasks from the role
   configuration:

--- a/test/helper.lua
+++ b/test/helper.lua
@@ -297,4 +297,11 @@ function helpers.get_error_function(error_msg)
     end
 end
 
+function helpers.create_persistent_function(name, body)
+    box.schema.func.create(name, {
+        body = body or "function(...) return true end",
+        if_not_exists = true
+    })
+end
+
 return helpers


### PR DESCRIPTION
A user can configure the role with persistent functions as callback for task.

Closes #153