### PR TITLE
Release 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Added ability to use persistent functions in `box.func` with cartridge. User can configure
-  the role with persistent functions as callback for task.
-
 ### Changed
 
 ### Fixed
+
+## 1.5.0 - 2023-08-23
+
+The release adds an ability to use functions from `box.func` with the Tarantool
+Cartridge role.
+
+### Added
+
+- An ability to use persistent functions in `box.func` with cartridge. A user
+  can configure the role with persistent functions as callback for a
+  task (#153).
 
 ## 1.4.0 - 2023-03-16
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+tarantool-expirationd (1.5.0-1) unstable; urgency=medium
+
+  * Add an ability to use persistent functions in `box.func` with cartridge.
+
+ -- Oleg Jukovec <oleg.jukovec@tarantool.org>  Wed, 23 Aug 2023 12:00:00 +0300
+
 tarantool-expirationd (1.4.0-1) unstable; urgency=medium
 
   * Add _VERSION constant

--- a/expirationd/version.lua
+++ b/expirationd/version.lua
@@ -1,4 +1,4 @@
 -- Сontains the module version.
 -- Requires manual update in case of release commit.
 
-return '1.4.0'
+return '1.5.0'

--- a/rpm/tarantool-expirationd.spec
+++ b/rpm/tarantool-expirationd.spec
@@ -40,6 +40,10 @@ install -m 0644 cartridge/roles/expirationd.lua %{buildroot}%{_datarootdir}/tara
 
 %changelog
 
+* Wed Aug 23 2023 Oleg Jukovec <oleg.jukovec@tarantool.org> 1.5.0-1
+
+- Add an ability to use persistent functions in `box.func` with cartridge.
+
 * Thu Mar 16 2023 Oleg Jukovec <oleg.jukovec@tarantool.org> 1.4.0-1
 
 - Add _VERSION constant.


### PR DESCRIPTION
## Overview

The release adds an ability to use functions from `box.func` with the Tarantool Cartridge role.

## Breaking changes

None.

## New features

* An ability to use persistent functions in `box.func` with cartridge. A user can configure the role with persistent functions as callback for a task (#153).