### PR TITLE
release 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Added the ability to run without a user Lua-code.
-
 ### Changed
+
+### Fixed
+
+## 1.7.0 - 2025-09-17
+
+This release improves flexibility of configuration and fixes role handling issues.
+
+### Added
+
+- Added the ability to run without a user Lua-code.
 
 ### Fixed
 

--- a/expirationd/version.lua
+++ b/expirationd/version.lua
@@ -1,4 +1,4 @@
 -- Сontains the module version.
 -- Requires manual update in case of release commit.
 
-return '1.6.0'
+return '1.7.0'


### PR DESCRIPTION
### Added

- Added the ability to run without a user Lua-code.

### Fixed

- Fix `is_master_only` option. Now it runs on master correctly. 
- Fixed restrictions on the order of role enable.