### PR TITLE
ci: bump Ubuntu version in reusable_testing

### DIFF
--- a/.github/workflows/reusable_testing.yml
+++ b/.github/workflows/reusable_testing.yml
@@ -5,13 +5,13 @@ on:
     inputs:
       artifact_name:
         description: The name of the Tarantool build artifact
-        default: ubuntu-focal
+        default: ubuntu-noble
         required: false
         type: string
 
 jobs:
   run_tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Clone the expirationd module
         uses: actions/checkout@v4


### PR DESCRIPTION
This commit bumps the Ubuntu distro version up to 24.04 (noble) in reusable_testing workflow, since Ubuntu 22.04 (jammy) leads to dpkg conflicts in the integrational testing with Tarantool.

Needed for tarantool/tarantool#11220

---

Unfortunately, our integrational workflow supports the single version of build for any workflow we want to integrate with. Hence, we should use the same Ubuntu versions for all modules to avoid conflicts, see [this CI log](https://github.com/tarantool/tarantool/actions/runs/21243385208/job/61127470382?pr=11220#step:4:15).